### PR TITLE
refac: modularize kroma deploy

### DIFF
--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -147,8 +147,17 @@ def devnet_l1_allocs(paths):
       'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
     }, cwd=paths.contracts_bedrock_dir)
 
-    shutil.move(src=paths.forge_l1_dump_path, dst=paths.allocs_l1_path)
+    # To avoid address collisions during create1 deployments, we use a separate test account
+    # instead of the Optimism sender EOA. (optimism uses dev account index 3, we use index 4)
+    fqn = 'scripts/deploy/KromaDeploy.s.sol:KromaDeploy'
+    run_command([
+      'forge', 'script', fqn, "--sig", "runWithStateDump()", "--sender", "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+    ], env={
+      'DEPLOYMENT_OUTFILE': paths.l1_deployments_path,
+      'DEPLOY_CONFIG_PATH': paths.devnet_config_path,
+    }, cwd=paths.contracts_bedrock_dir)
 
+    shutil.move(src=paths.forge_l1_dump_path, dst=paths.allocs_l1_path)
     shutil.copy(paths.l1_deployments_path, paths.addresses_json_path)
 
 

--- a/packages/contracts-bedrock/interfaces/L1/IColosseum.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IColosseum.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
 import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
 import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
 import { KromaTypes } from "src/libraries/KromaTypes.sol";
@@ -51,7 +51,7 @@ interface IColosseum {
 
     function BISECTION_TIMEOUT() external view returns (uint256);
     function CREATION_PERIOD_SECONDS() external view returns (uint256);
-    function L2_ORACLE() external view returns (IL2OutputOracle);
+    function L2_ORACLE() external view returns (IKromaL2OutputOracle);
     function L2_ORACLE_SUBMISSION_INTERVAL() external view returns (uint256);
     function PROVING_TIMEOUT() external view returns (uint256);
     function SECURITY_COUNCIL() external view returns (ISecurityCouncil);
@@ -107,7 +107,7 @@ interface IColosseum {
         uint256[] memory _segmentsLengths
     ) external;
     function isInCreationPeriod(uint256 _outputIndex) external view returns (bool);
-    function l2Oracle() external view returns (IL2OutputOracle);
+    function l2Oracle() external view returns (IKromaL2OutputOracle);
     function l2OracleSubmissionInterval() external view returns (uint256);
     function proveFaultWithZkVm(uint256 _outputIndex, uint256 _pos, KromaTypes.ZkVmProof memory _zkVmProof) external;
     function provingTimeout() external view returns (uint256);

--- a/packages/contracts-bedrock/interfaces/L1/IKromaL2OutputOracle.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IKromaL2OutputOracle.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { KromaTypes } from "src/libraries/KromaTypes.sol";
+import { Types } from "src/libraries/Types.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+import {IColosseum} from "./IColosseum.sol";
+
+interface IKromaL2OutputOracle {
+    event Initialized(uint8 version);
+    event OutputReplaced(uint256 indexed outputIndex, address indexed newSubmitter, bytes32 newOutputRoot);
+    event OutputSubmitted(
+        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
+    );
+
+    function COLOSSEUM() external view returns (address);
+    function FINALIZATION_PERIOD_SECONDS() external view returns (uint256);
+    function L2_BLOCK_TIME() external view returns (uint256);
+    function SUBMISSION_INTERVAL() external view returns (uint256);
+    function VALIDATOR_MANAGER() external view returns (IValidatorManager);
+    function colosseum() external view returns (address);
+    function computeL2Timestamp(uint256 _l2BlockNumber) external view returns (uint256);
+    function finalizationPeriodSeconds() external view returns (uint256);
+    function finalizedAt(uint256 _outputIndex) external view returns (uint256);
+    function getL2Output(uint256 _l2OutputIndex) external view returns (KromaTypes.CheckpointOutput memory);
+    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (KromaTypes.CheckpointOutput memory);
+    function getL2OutputIndexAfter(uint256 _l2BlockNumber) external view returns (uint256);
+    function getSubmitter(uint256 _outputIndex) external view returns (address);
+    function initialize(
+        address _validatorManager,
+        address _colosseum,
+        uint256 _submissionInterval,
+        uint256 _l2BlockTime,
+        uint256 _startingBlockNumber,
+        uint256 _startingTimestamp,
+        uint256 _finalizationPeriodSeconds
+    ) external;
+    function isFinalized(uint256 _outputIndex) external view returns (bool);
+    function l2BlockTime() external view returns (uint256);
+    function latestBlockNumber() external view returns (uint256);
+    function latestOutputIndex() external view returns (uint256);
+    function nextBlockNumber() external view returns (uint256);
+    function nextFinalizeOutputIndex() external view returns (uint256);
+    function nextOutputIndex() external view returns (uint256);
+    function nextOutputMinL2Timestamp() external view returns (uint256);
+    function replaceL2Output(uint256 _l2OutputIndex, bytes32 _newOutputRoot, address _submitter) external;
+    function setNextFinalizeOutputIndex(uint256 _outputIndex) external;
+    function startingBlockNumber() external view returns (uint256);
+    function startingTimestamp() external view returns (uint256);
+    function submissionInterval() external view returns (uint256);
+    function submitL2Output(bytes32 _outputRoot, uint256 _l2BlockNumber, bytes32 _l1BlockHash, uint256 _l1BlockNumber)
+        external
+        payable;
+    function validatorManager() external view returns (IValidatorManager);
+    function version() external view returns (string memory);
+    function __constructor__() external;
+
+    // TODO(ayaan) : remove this after fixing compile errors at deploy and tests.
+    function PROPOSER() external view returns (address);
+    function CHALLENGER() external view returns (address);
+    function proposer() external view returns (address);
+    function challenger() external view returns (address);
+    function proposeL2Output(
+        bytes32 _outputRoot,
+        uint256 _l2BlockNumber,
+        bytes32 _l1BlockHash,
+        uint256 _l1BlockNumber
+    )
+        external
+        payable;
+}

--- a/packages/contracts-bedrock/interfaces/L1/IL2OutputOracle.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IL2OutputOracle.sol
@@ -1,65 +1,42 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { KromaTypes } from "src/libraries/KromaTypes.sol";
 import { Types } from "src/libraries/Types.sol";
-import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
-import {IColosseum} from "./IColosseum.sol";
 
 interface IL2OutputOracle {
     event Initialized(uint8 version);
-    event OutputReplaced(uint256 indexed outputIndex, address indexed newSubmitter, bytes32 newOutputRoot);
-    event OutputSubmitted(
+    event OutputProposed(
         bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
     );
+    event OutputsDeleted(uint256 indexed prevNextOutputIndex, uint256 indexed newNextOutputIndex);
 
-    function COLOSSEUM() external view returns (address);
+    function CHALLENGER() external view returns (address);
     function FINALIZATION_PERIOD_SECONDS() external view returns (uint256);
     function L2_BLOCK_TIME() external view returns (uint256);
+    function PROPOSER() external view returns (address);
     function SUBMISSION_INTERVAL() external view returns (uint256);
-    function VALIDATOR_MANAGER() external view returns (IValidatorManager);
-    function colosseum() external view returns (address);
+    function challenger() external view returns (address);
     function computeL2Timestamp(uint256 _l2BlockNumber) external view returns (uint256);
+    function deleteL2Outputs(uint256 _l2OutputIndex) external;
     function finalizationPeriodSeconds() external view returns (uint256);
-    function finalizedAt(uint256 _outputIndex) external view returns (uint256);
-    function getL2Output(uint256 _l2OutputIndex) external view returns (KromaTypes.CheckpointOutput memory);
-    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (KromaTypes.CheckpointOutput memory);
+    function getL2Output(uint256 _l2OutputIndex) external view returns (Types.OutputProposal memory);
+    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (Types.OutputProposal memory);
     function getL2OutputIndexAfter(uint256 _l2BlockNumber) external view returns (uint256);
-    function getSubmitter(uint256 _outputIndex) external view returns (address);
     function initialize(
-        address _validatorManager,
-        address _colosseum,
         uint256 _submissionInterval,
         uint256 _l2BlockTime,
         uint256 _startingBlockNumber,
         uint256 _startingTimestamp,
+        address _proposer,
+        address _challenger,
         uint256 _finalizationPeriodSeconds
-    ) external;
-    function isFinalized(uint256 _outputIndex) external view returns (bool);
+    )
+        external;
     function l2BlockTime() external view returns (uint256);
     function latestBlockNumber() external view returns (uint256);
     function latestOutputIndex() external view returns (uint256);
     function nextBlockNumber() external view returns (uint256);
-    function nextFinalizeOutputIndex() external view returns (uint256);
     function nextOutputIndex() external view returns (uint256);
-    function nextOutputMinL2Timestamp() external view returns (uint256);
-    function replaceL2Output(uint256 _l2OutputIndex, bytes32 _newOutputRoot, address _submitter) external;
-    function setNextFinalizeOutputIndex(uint256 _outputIndex) external;
-    function startingBlockNumber() external view returns (uint256);
-    function startingTimestamp() external view returns (uint256);
-    function submissionInterval() external view returns (uint256);
-    function submitL2Output(bytes32 _outputRoot, uint256 _l2BlockNumber, bytes32 _l1BlockHash, uint256 _l1BlockNumber)
-        external
-        payable;
-    function validatorManager() external view returns (IValidatorManager);
-    function version() external view returns (string memory);
-    function __constructor__() external;
-
-    // TODO(ayaan) : remove this after fixing compile errors at deploy and tests.
-    function PROPOSER() external view returns (address);
-    function CHALLENGER() external view returns (address);
-    function proposer() external view returns (address);
-    function challenger() external view returns (address);
     function proposeL2Output(
         bytes32 _outputRoot,
         uint256 _l2BlockNumber,
@@ -68,4 +45,11 @@ interface IL2OutputOracle {
     )
         external
         payable;
+    function proposer() external view returns (address);
+    function startingBlockNumber() external view returns (uint256);
+    function startingTimestamp() external view returns (uint256);
+    function submissionInterval() external view returns (uint256);
+    function version() external view returns (string memory);
+
+    function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IValidatorManager.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IValidatorManager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
 
 /// @title IValidatorManager
 /// @notice Interface for ValidatorManager contract.
@@ -17,7 +17,7 @@ interface IValidatorManager {
     }
 
     struct InitializationParams {
-        IL2OutputOracle _l2Oracle;
+        IKromaL2OutputOracle _l2Oracle;
         IAssetManager _assetManager;
         address _trustedValidator;
         uint128 _commissionChangeDelaySeconds;
@@ -73,7 +73,7 @@ interface IValidatorManager {
     function COMMISSION_RATE_DENOM() external view returns (uint128);
     function HARD_JAIL_PERIOD_SECONDS() external view returns (uint128);
     function JAIL_THRESHOLD() external view returns (uint128);
-    function L2_ORACLE() external view returns (IL2OutputOracle);
+    function L2_ORACLE() external view returns (IKromaL2OutputOracle);
     function MAX_OUTPUT_FINALIZATIONS() external view returns (uint128);
     function MIN_ACTIVATE_AMOUNT() external view returns (uint128);
     function MIN_REGISTER_AMOUNT() external view returns (uint128);
@@ -102,7 +102,7 @@ interface IValidatorManager {
     function isActive(address validator) external view returns (bool);
     function jailExpiresAt(address validator) external view returns (uint128);
     function jailThreshold() external view returns (uint128);
-    function l2Oracle() external view returns (IL2OutputOracle);
+    function l2Oracle() external view returns (IKromaL2OutputOracle);
     function maxOutputFinalizations() external view returns (uint128);
     function minActiveAmount() external view returns (uint128);
     function minRegisterAmount() external view returns (uint128);

--- a/packages/contracts-bedrock/interfaces/legacy/ILegacyOptimismPortal.sol
+++ b/packages/contracts-bedrock/interfaces/legacy/ILegacyOptimismPortal.sol
@@ -4,9 +4,9 @@ pragma solidity ^0.8.0;
 import { Types } from "src/libraries/Types.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
-import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
+import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
 
-interface IOptimismPortal {
+interface ILegacyOptimismPortal {
     error BadTarget();
     error CallPaused();
     error ContentLengthMismatch();
@@ -56,13 +56,13 @@ interface IOptimismPortal {
     function finalizedWithdrawals(bytes32) external view returns (bool);
     function guardian() external view returns (address);
     function initialize(
-        IKromaL2OutputOracle _l2Oracle,
+        IL2OutputOracle _l2Oracle,
         ISystemConfig _systemConfig,
         ISuperchainConfig _superchainConfig
     )
         external;
     function isOutputFinalized(uint256 _l2OutputIndex) external view returns (bool);
-    function l2Oracle() external view returns (IKromaL2OutputOracle);
+    function l2Oracle() external view returns (IL2OutputOracle);
     function l2Sender() external view returns (address);
     function minimumGasLimit(uint64 _byteCount) external pure returns (uint64);
     function params() external view returns (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum); // nosemgrep

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -352,19 +352,23 @@ library ChainAssertions {
             require(oracle.submissionInterval() == _cfg.l2OutputOracleSubmissionInterval(), "CHECK-L2OO-30");
             require(oracle.L2_BLOCK_TIME() == _cfg.l2BlockTime(), "CHECK-L2OO-40");
             require(oracle.l2BlockTime() == _cfg.l2BlockTime(), "CHECK-L2OO-50");
-            require(oracle.FINALIZATION_PERIOD_SECONDS() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-60");
-            require(oracle.finalizationPeriodSeconds() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-70");
-            require(oracle.startingBlockNumber() == _cfg.l2OutputOracleStartingBlockNumber(), "CHECK-L2OO-80");
-            require(oracle.startingTimestamp() == _l2OutputOracleStartingTimestamp, "CHECK-L2OO-90");
+            require(oracle.PROPOSER() == _cfg.l2OutputOracleProposer(), "CHECK-L2OO-60");
+            require(oracle.proposer() == _cfg.l2OutputOracleProposer(), "CHECK-L2OO-70");
+            require(oracle.CHALLENGER() == _cfg.l2OutputOracleChallenger(), "CHECK-L2OO-80");
+            require(oracle.challenger() == _cfg.l2OutputOracleChallenger(), "CHECK-L2OO-90");
+            require(oracle.FINALIZATION_PERIOD_SECONDS() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-100");
+            require(oracle.finalizationPeriodSeconds() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-110");
+            require(oracle.startingBlockNumber() == _cfg.l2OutputOracleStartingBlockNumber(), "CHECK-L2OO-120");
+            require(oracle.startingTimestamp() == _l2OutputOracleStartingTimestamp, "CHECK-L2OO-130");
         } else {
             require(oracle.SUBMISSION_INTERVAL() == 1, "CHECK-L2OO-140");
             require(oracle.submissionInterval() == 1, "CHECK-L2OO-150");
             require(oracle.L2_BLOCK_TIME() == 1, "CHECK-L2OO-160");
             require(oracle.l2BlockTime() == 1, "CHECK-L2OO-170");
-            require(address(oracle.VALIDATOR_MANAGER()) == address(0), "CHECK-L200-180");
-            require(address(oracle.validatorManager()) == address(0), "CHECK-L200-190");
-            require(oracle.COLOSSEUM() == address(0), "CHECK-L2OO-200");
-            require(oracle.colosseum() == address(0), "CHECK-L2OO-210");
+            require(oracle.PROPOSER() == address(0), "CHECK-L2OO-180");
+            require(oracle.proposer() == address(0), "CHECK-L2OO-190");
+            require(oracle.CHALLENGER() == address(0), "CHECK-L2OO-200");
+            require(oracle.challenger() == address(0), "CHECK-L2OO-210");
             require(oracle.FINALIZATION_PERIOD_SECONDS() == 0, "CHECK-L2OO-220");
             require(oracle.finalizationPeriodSeconds() == 0, "CHECK-L2OO-230");
             require(oracle.startingBlockNumber() == 0, "CHECK-L2OO-240");
@@ -585,7 +589,7 @@ library ChainAssertions {
         bytes32 slotVal = vm.load(_contractAddress, bytes32(_slot));
         uint8 val = uint8((uint256(slotVal) >> (_offset * 8)) & 0xFF);
         require(
-            val >= uint8(1) || val == uint8(0xff),
+            val == uint8(1) || val == uint8(0xff),
             "ChainAssertions: storage value is not 1 or 0xff at the given slot and offset"
         );
     }

--- a/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/ChainAssertions.sol
@@ -352,14 +352,10 @@ library ChainAssertions {
             require(oracle.submissionInterval() == _cfg.l2OutputOracleSubmissionInterval(), "CHECK-L2OO-30");
             require(oracle.L2_BLOCK_TIME() == _cfg.l2BlockTime(), "CHECK-L2OO-40");
             require(oracle.l2BlockTime() == _cfg.l2BlockTime(), "CHECK-L2OO-50");
-            require(address(oracle.VALIDATOR_MANAGER()) == address(_contracts.ValidatorManager), "CHECK-L200-60");
-            require(address(oracle.validatorManager()) == address(_contracts.ValidatorManager), "CHECK-L200-70");
-            require(oracle.COLOSSEUM() == address(_contracts.Colosseum), "CHECK-L2OO-80");
-            require(oracle.colosseum() == address(_contracts.Colosseum), "CHECK-L2OO-90");
-            require(oracle.FINALIZATION_PERIOD_SECONDS() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-100");
-            require(oracle.finalizationPeriodSeconds() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-110");
-            require(oracle.startingBlockNumber() == _cfg.l2OutputOracleStartingBlockNumber(), "CHECK-L2OO-120");
-            require(oracle.startingTimestamp() == _l2OutputOracleStartingTimestamp, "CHECK-L2OO-130");
+            require(oracle.FINALIZATION_PERIOD_SECONDS() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-60");
+            require(oracle.finalizationPeriodSeconds() == _cfg.finalizationPeriodSeconds(), "CHECK-L2OO-70");
+            require(oracle.startingBlockNumber() == _cfg.l2OutputOracleStartingBlockNumber(), "CHECK-L2OO-80");
+            require(oracle.startingTimestamp() == _l2OutputOracleStartingTimestamp, "CHECK-L2OO-90");
         } else {
             require(oracle.SUBMISSION_INTERVAL() == 1, "CHECK-L2OO-140");
             require(oracle.submissionInterval() == 1, "CHECK-L2OO-150");

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -23,20 +23,11 @@ import {
     DeployImplementationsInterop,
     DeployImplementationsOutput
 } from "scripts/deploy/DeployImplementations.s.sol";
-import { KromaInitializers } from "scripts/deploy/kroma/KromaInitializers.sol";
-import { KromaDeployer } from "scripts/deploy/kroma/KromaDeployer.sol";
-import { KromaConfigBuilder } from "scripts/deploy/kroma/KromaConfigBuilder.sol";
-import { KromaDeployInput, KromaDeployOutput } from "scripts/deploy/kroma/KromaDeployTypes.sol";
-import { KromaPostDeployAssertions, KromaChainAssertions } from "scripts/deploy/kroma/KromaChainAssertions.sol";
 
 // Contracts
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
-import { AssetManager } from "src/L1/AssetManager.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
-import { ZKProofVerifier } from "src/L1/ZKProofVerifier.sol";
 
 // Libraries
-import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Types } from "scripts/libraries/Types.sol";
 import { Duration } from "src/dispute/lib/LibUDT.sol";
@@ -61,9 +52,6 @@ import { IDelayedWETH } from "interfaces/dispute/IDelayedWETH.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IMIPS } from "interfaces/cannon/IMIPS.sol";
 import { IPreimageOracle } from "interfaces/cannon/IPreimageOracle.sol";
-import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /// @title Deploy
 /// @notice Script used to deploy a bedrock system. The entire system is deployed within the `run` function.
@@ -233,44 +221,6 @@ contract Deploy is Deployer {
             );
             vm.stopPrank();
         } else {
-            // [Kroma: START]
-
-            // Step 1: Build the deployment input for the Kroma system.
-            // This uses values from the global deployment config (cfg).
-            KromaDeployInput memory kromaInput = KromaConfigBuilder.fromConfig(cfg);
-
-            // Step 2: Precompute the deterministic address of the L2OutputOracle proxy.
-            // This proxy address is injected into the deployment input because it is used as a constructor
-            // parameter in some Kroma contracts before the actual deployment occurs.
-            kromaInput.l2OutputOracle =
-                IL2OutputOracle(calculateERC1967ProxyWithOwner("L2OutputOracleProxy", mustGetAddress("ProxyAdmin")));
-
-            // Step 3: Deploy and initialize all Kroma L1 contracts (both implementations and proxies).
-            // - deployImpl: function to deploy logic (implementation) contracts
-            // - deployProxy: function to deploy ERC1967 proxy contracts
-            // - proxyAdmin: the ProxyAdmin responsible for managing upgrades
-            // - input: the deployment input configuration
-            // - vm: Forge cheatcode interface used for broadcasting
-            KromaDeployOutput memory kromaOutput = KromaDeployer.deployAll({
-                deployProxy: deployERC1967Proxy,
-                deployImpl: deployImpl,
-                proxyAdmin: IProxyAdmin(payable(mustGetAddress("ProxyAdmin"))),
-                input: kromaInput,
-                vm: vm
-            });
-
-            // Step 4a: Run post-deployment assertions on the implementation contracts.
-            // These assertions verify that the implementation contracts were deployed correctly and are uninitialized.
-            // isProxy = false
-            KromaPostDeployAssertions.runPostDeployAssertions(kromaInput, kromaOutput, cfg, false);
-
-            // Step 4b: Run post-deployment assertions on the proxy contracts.
-            // These assertions ensure that the proxies were properly upgraded and initialized.
-            // isProxy = true
-            KromaPostDeployAssertions.runPostDeployAssertions(kromaInput, kromaOutput, cfg, true);
-
-            // [Kroma: END]
-
             // The L2OutputOracle is not deployed by the OPCM, we deploy the proxy and initialize it here.
             deployERC1967Proxy("L2OutputOracleProxy");
             initializeL2OutputOracle();
@@ -519,29 +469,6 @@ contract Deploy is Deployer {
         addr_ = address(proxy);
     }
 
-    /// @notice Calaulate deterministic ERC1967Proxy contract address with a specified owner.
-    /// @param _name The name of the proxy contract to be deployed.
-    /// @param _proxyOwner The address of the owner of the proxy contract.
-    /// @return addr_ The address of the deployed proxy contract.
-    function calculateERC1967ProxyWithOwner(
-        string memory _name,
-        address _proxyOwner
-    )
-        public
-        view
-        returns (address addr_)
-    {
-        bytes32 salt = keccak256(abi.encode(_implSalt(), _name));
-
-        bytes32 bytecodeHash = keccak256(
-            abi.encodePacked(
-                vm.getCode("Proxy"),
-                DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (_proxyOwner)))
-            )
-        );
-        addr_ = vm.computeCreate2Address(salt, bytecodeHash);
-    }
-
     /// @notice Deploy the DataAvailabilityChallengeProxy
     function deployDataAvailabilityChallengeProxy() public broadcast returns (address addr_) {
         address proxyAdmin = mustGetAddress("ProxyAdmin");
@@ -621,18 +548,6 @@ contract Deploy is Deployer {
         addr_ = address(dac);
     }
 
-    /// @notice Deploys an implementation contract using CREATE1 with the given name and constructor arguments.
-    /// @dev This function wraps `DeployUtils.create1` and adds labeling for improved traceability in debugging.
-    /// @param _name The name of the contract being deployed.
-    /// @param _data ABI-encoded constructor arguments for the contract.
-    /// @return impl The address of the deployed implementation contract.
-    function deployImpl(string memory _name, bytes memory _data) public returns (address impl) {
-        vm.startBroadcast(msg.sender);
-        impl = DeployUtils.create1({ _name: _name, _args: _data });
-        vm.stopBroadcast();
-        vm.label(impl, string.concat(_name, "Impl"));
-    }
-
     ////////////////////////////////////////////////////////////////
     //                    Initialize Functions                    //
     ////////////////////////////////////////////////////////////////
@@ -690,8 +605,6 @@ contract Deploy is Deployer {
         console.log("Upgrading and initializing L2OutputOracle proxy");
         address l2OutputOracleProxy = mustGetAddress("L2OutputOracleProxy");
         address l2OutputOracle = mustGetAddress("L2OutputOracle");
-        address validatorManagerProxy = mustGetAddress("ValidatorManagerProxy");
-        address colosseumProxy = mustGetAddress("ColosseumProxy");
 
         IProxyAdmin proxyAdmin = IProxyAdmin(payable(mustGetAddress("ProxyAdmin")));
         proxyAdmin.upgradeAndCall({
@@ -700,8 +613,8 @@ contract Deploy is Deployer {
             _data: abi.encodeCall(
                 IL2OutputOracle.initialize,
                 (
-                    validatorManagerProxy,
-                    colosseumProxy,
+                    address(0),
+                    address(0),
                     cfg.l2OutputOracleSubmissionInterval(),
                     cfg.l2BlockTime(),
                     cfg.l2OutputOracleStartingBlockNumber(),

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -23,6 +23,11 @@ import {
     DeployImplementationsInterop,
     DeployImplementationsOutput
 } from "scripts/deploy/DeployImplementations.s.sol";
+import { KromaInitializers } from "scripts/deploy/kroma/KromaInitializers.sol";
+import { KromaDeployer } from "scripts/deploy/kroma/KromaDeployer.sol";
+import { KromaConfigBuilder } from "scripts/deploy/kroma/KromaConfigBuilder.sol";
+import { KromaDeployInput, KromaDeployOutput } from "scripts/deploy/kroma/KromaDeployTypes.sol";
+import { KromaPostDeployAssertions, KromaChainAssertions } from "scripts/deploy/kroma/KromaChainAssertions.sol";
 
 // Contracts
 import { OPContractsManager } from "src/L1/OPContractsManager.sol";
@@ -136,18 +141,8 @@ contract Deploy is Deployer {
             L1ERC721Bridge: getAddress("L1ERC721BridgeProxy"),
             ProtocolVersions: getAddress("ProtocolVersionsProxy"),
             SuperchainConfig: getAddress("SuperchainConfigProxy"),
-            OPContractsManager: getAddress("OPContractsManager"),
-            // [Kroma: START]
-            AssetManager: getAddress("AssetManagerProxy"),
-            Colosseum: getAddress("ColosseumProxy"),
-            SecurityCouncil: getAddress("SecurityCouncilProxy"),
-            SecurityCouncilToken: getAddress("SecurityCouncilTokenProxy"),
-            TimeLock: getAddress("TimeLockProxy"),
-            UpgradeGovernor: getAddress("UpgradeGovernorProxy"),
-            ValidatorManager: getAddress("ValidatorManagerProxy"),
-            ZkProofVerifier: getAddress("ZkProofVerifierProxy")
+            OPContractsManager: getAddress("OPContractsManager")
         });
-        // [Kroma: END]
     }
 
     /// @notice Returns the impl addresses, not reverting if any are unset.
@@ -167,18 +162,8 @@ contract Deploy is Deployer {
             L1ERC721Bridge: getAddress("L1ERC721Bridge"),
             ProtocolVersions: getAddress("ProtocolVersions"),
             SuperchainConfig: getAddress("SuperchainConfig"),
-            OPContractsManager: getAddress("OPContractsManager"),
-            // [Kroma: START]
-            AssetManager: getAddress("AssetManager"),
-            Colosseum: getAddress("Colosseum"),
-            SecurityCouncil: getAddress("SecurityCouncil"),
-            SecurityCouncilToken: getAddress("SecurityCouncilToken"),
-            TimeLock: getAddress("TimeLock"),
-            UpgradeGovernor: getAddress("UpgradeGovernor"),
-            ValidatorManager: getAddress("ValidatorManager"),
-            ZkProofVerifier: getAddress("ZkProofVerifier")
+            OPContractsManager: getAddress("OPContractsManager")
         });
-        // [Kroma: END]
     }
 
     ////////////////////////////////////////////////////////////////
@@ -248,6 +233,44 @@ contract Deploy is Deployer {
             );
             vm.stopPrank();
         } else {
+            // [Kroma: START]
+
+            // Step 1: Build the deployment input for the Kroma system.
+            // This uses values from the global deployment config (cfg).
+            KromaDeployInput memory kromaInput = KromaConfigBuilder.fromConfig(cfg);
+
+            // Step 2: Precompute the deterministic address of the L2OutputOracle proxy.
+            // This proxy address is injected into the deployment input because it is used as a constructor
+            // parameter in some Kroma contracts before the actual deployment occurs.
+            kromaInput.l2OutputOracle =
+                IL2OutputOracle(calculateERC1967ProxyWithOwner("L2OutputOracleProxy", mustGetAddress("ProxyAdmin")));
+
+            // Step 3: Deploy and initialize all Kroma L1 contracts (both implementations and proxies).
+            // - deployImpl: function to deploy logic (implementation) contracts
+            // - deployProxy: function to deploy ERC1967 proxy contracts
+            // - proxyAdmin: the ProxyAdmin responsible for managing upgrades
+            // - input: the deployment input configuration
+            // - vm: Forge cheatcode interface used for broadcasting
+            KromaDeployOutput memory kromaOutput = KromaDeployer.deployAll({
+                deployProxy: deployERC1967Proxy,
+                deployImpl: deployImpl,
+                proxyAdmin: IProxyAdmin(payable(mustGetAddress("ProxyAdmin"))),
+                input: kromaInput,
+                vm: vm
+            });
+
+            // Step 4a: Run post-deployment assertions on the implementation contracts.
+            // These assertions verify that the implementation contracts were deployed correctly and are uninitialized.
+            // isProxy = false
+            KromaPostDeployAssertions.runPostDeployAssertions(kromaInput, kromaOutput, cfg, false);
+
+            // Step 4b: Run post-deployment assertions on the proxy contracts.
+            // These assertions ensure that the proxies were properly upgraded and initialized.
+            // isProxy = true
+            KromaPostDeployAssertions.runPostDeployAssertions(kromaInput, kromaOutput, cfg, true);
+
+            // [Kroma: END]
+
             // The L2OutputOracle is not deployed by the OPCM, we deploy the proxy and initialize it here.
             deployERC1967Proxy("L2OutputOracleProxy");
             initializeL2OutputOracle();
@@ -347,10 +370,6 @@ contract Deploy is Deployer {
         if (_isInterop) {
             di = DeployImplementations(new DeployImplementationsInterop());
         }
-        // [Kroma: START]
-        dii.set(dii.sp1Verifier.selector, cfg.zkProofVerifierSP1Verifier());
-        dii.set(dii.vKey.selector, cfg.zkProofVerifierVKey());
-        // [Kroma: END]
         di.run(dii, dio);
 
         // Temporary patch for legacy system
@@ -371,18 +390,6 @@ contract Deploy is Deployer {
         save("DelayedWETH", address(dio.delayedWETHImpl()));
         save("PreimageOracle", address(dio.preimageOracleSingleton()));
         save("Mips", address(dio.mipsSingleton()));
-
-        // [Kroma: START]
-        save("AssetManager", address(dio.assetManagerImpl()));
-        save("Colosseum", address(dio.colosseumImpl()));
-        save("SecurityCouncil", address(dio.securityCouncilImpl()));
-        save("SecurityCouncilToken", address(dio.securityCouncilTokenImpl()));
-        save("TimeLock", address(dio.timeLockImpl()));
-        save("UpgradeGovernor", address(dio.upgradeGovernorImpl()));
-        save("ValidatorManager", address(dio.validatorManagerImpl()));
-        save("ZKProofVerifier", address(dio.zkProofVerifierImpl()));
-        // [Kroma: END]
-
         save("OPContractsManager", address(dio.opcm()));
 
         Types.ContractSet memory contracts = _impls();
@@ -421,7 +428,7 @@ contract Deploy is Deployer {
         address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
         OPContractsManager opcm = OPContractsManager(mustGetAddress("OPContractsManager"));
 
-        OPContractsManager.DeployInput memory deployInput = getDeployInput(opcm);
+        OPContractsManager.DeployInput memory deployInput = getDeployInput();
         OPContractsManager.DeployOutput memory deployOutput = opcm.deploy(deployInput);
 
         // Save all deploy outputs from the OPCM, in the order they are declared in the DeployOutput struct
@@ -440,18 +447,6 @@ contract Deploy is Deployer {
         save("AnchorStateRegistry", address(deployOutput.anchorStateRegistryImpl));
         save("PermissionedDisputeGame", address(deployOutput.permissionedDisputeGame));
         save("OptimismPortalProxy", address(deployOutput.optimismPortalProxy));
-
-        // [Kroma: START]
-        save("AssetManagerProxy", address(deployOutput.assetManagerProxy));
-        save("ColosseumProxy", address(deployOutput.colosseumProxy));
-        save("SecurityCouncilProxy", address(deployOutput.securityCouncilProxy));
-        save("SecurityCouncilTokenProxy", address(deployOutput.securityCouncilTokenProxy));
-        save("TimeLockProxy", address(deployOutput.timeLockProxy));
-        save("UpgradeGovernorProxy", address(deployOutput.upgradeGovernorProxy));
-        save("ValidatorManagerProxy", address(deployOutput.validatorManagerProxy));
-        save("ZkProofVerifierProxy", address(deployOutput.zkProofVerifierProxy));
-        save("KromaGovernanceTokenProxy", address(deployOutput.kromaGovernanceTokenProxy));
-        // [Kroma: END]
 
         // Check if the permissionless game implementation is already set
         IDisputeGameFactory factory = IDisputeGameFactory(mustGetAddress("DisputeGameFactoryProxy"));
@@ -624,6 +619,18 @@ contract Deploy is Deployer {
             })
         );
         addr_ = address(dac);
+    }
+
+    /// @notice Deploys an implementation contract using CREATE1 with the given name and constructor arguments.
+    /// @dev This function wraps `DeployUtils.create1` and adds labeling for improved traceability in debugging.
+    /// @param _name The name of the contract being deployed.
+    /// @param _data ABI-encoded constructor arguments for the contract.
+    /// @return impl The address of the deployed implementation contract.
+    function deployImpl(string memory _name, bytes memory _data) public returns (address impl) {
+        vm.startBroadcast(msg.sender);
+        impl = DeployUtils.create1({ _name: _name, _args: _data });
+        vm.stopBroadcast();
+        vm.label(impl, string.concat(_name, "Impl"));
     }
 
     ////////////////////////////////////////////////////////////////
@@ -1049,7 +1056,7 @@ contract Deploy is Deployer {
     }
 
     /// @notice Get the DeployInput struct to use for testing
-    function getDeployInput(OPContractsManager opcm) public view returns (OPContractsManager.DeployInput memory) {
+    function getDeployInput() public view returns (OPContractsManager.DeployInput memory) {
         OutputRoot memory testOutputRoot = OutputRoot({
             root: Hash.wrap(cfg.faultGameGenesisOutputRoot()),
             l2BlockNumber: cfg.faultGameGenesisBlock()
@@ -1068,15 +1075,7 @@ contract Deploy is Deployer {
             IAnchorStateRegistry.StartingAnchorRoot({ gameType: GameTypes.FAST, outputRoot: testOutputRoot });
         startingAnchorRoots[4] =
             IAnchorStateRegistry.StartingAnchorRoot({ gameType: GameTypes.ALPHABET, outputRoot: testOutputRoot });
-
-        // [Kroma: START]
-        // At this point, the contracts have not been deployed yet,
-        // but their deterministic deployment addresses are precomputed and injected.
-        address proxyAdmin = _computeProxyAdmin(opcm, address(opcm));
-
-        address l2OutputOracleProxy = calculateERC1967ProxyWithOwner("L2OutputOracleProxy", proxyAdmin);
-        // [Kroma: END]
-
+        string memory saltMixer = "salt mixer";
         return OPContractsManager.DeployInput({
             roles: OPContractsManager.Roles({
                 opChainProxyAdminOwner: msg.sender,
@@ -1097,41 +1096,8 @@ contract Deploy is Deployer {
             disputeMaxGameDepth: cfg.faultGameMaxDepth(),
             disputeSplitDepth: cfg.faultGameSplitDepth(),
             disputeClockExtension: Duration.wrap(uint64(cfg.faultGameClockExtension())),
-            disputeMaxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration())),
-            // [Kroma: START]
-            kgh: IERC721(cfg.assetManagerKgh()),
-            vault: cfg.assetManagerVault(),
-            minDelegationPeriod: cfg.assetManagerMinDelegationPeriod(),
-            bondAmount: cfg.assetManagerBondAmount(),
-            l2OutputOracle: IL2OutputOracle(l2OutputOracleProxy),
-            submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
-            creationPeriodSeconds: cfg.colosseumCreationPeriodSeconds(),
-            bisectionTimeout: cfg.colosseumBisectionTimeout(),
-            provingTimeout: cfg.colosseumProvingTimeout(),
-            segmentsLengths: cfg.getColosseumSegmentsLengths(),
-            timeLockMinDelaySeconds: cfg.timeLockMinDelaySeconds(),
-            initialVotingDelay: cfg.governorVotingDelayBlocks(),
-            initialVotingPeriod: cfg.governorVotingPeriodBlocks(),
-            initialProposalThreshold: cfg.governorProposalThreshold(),
-            votesQuorumFraction: cfg.governorVotesQuorumFractionPercent(),
-            trustedValidator: cfg.validatorManagerTrustedValidator(),
-            minRegisterAmount: cfg.validatorManagerMinRegisterAmount(),
-            minActivateAmount: cfg.validatorManagerMinActivateAmount(),
-            commissionChangeDelaySeconds: cfg.validatorManagerCommissionChangeDelaySeconds(),
-            roundDurationSeconds: cfg.validatorManagerRoundDurationSeconds(),
-            softJailPeriodSeconds: cfg.validatorManagerSoftJailPeriodSeconds(),
-            hardJailPeriodSeconds: cfg.validatorManagerHardJailPeriodSeconds(),
-            jailThreshold: cfg.validatorManagerJailThreshold(),
-            maxFinalizations: cfg.validatorManagerMaxFinalizations(),
-            baseReward: cfg.validatorManagerBaseReward()
+            disputeMaxClockDuration: Duration.wrap(uint64(cfg.faultGameMaxClockDuration()))
         });
-        // [Kroma: END]
-    }
-
-    function _computeProxyAdmin(OPContractsManager opcm, address owner) internal view returns (address) {
-        return opcm.computeDeployProxy(
-            cfg.l2ChainID(), owner, saltMixer, "ProxyAdmin", opcm.blueprints().proxyAdmin, address(opcm)
-        );
     }
 
     /// @notice Reset the initialized value on a proxy contract so that it can be initialized again

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -37,7 +37,7 @@ import { GameType, Claim, GameTypes, OutputRoot, Hash } from "src/dispute/lib/Ty
 // Interfaces
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
-import { IOptimismPortal } from "interfaces/L1/IOptimismPortal.sol";
+import { ILegacyOptimismPortal as IOptimismPortal } from "interfaces/legacy/ILegacyOptimismPortal.sol";
 import { IOptimismPortal2 } from "interfaces/L1/IOptimismPortal2.sol";
 import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -497,9 +497,10 @@ contract Deploy is Deployer {
         addr_ = DeployUtils.create2AndSave({
             _save: this,
             _salt: _implSalt(),
-            _name: "OptimismPortal",
+            _name: "LegacyOptimismPortal",
             _args: DeployUtils.encodeConstructor(abi.encodeCall(IOptimismPortal.__constructor__, ()))
         });
+        save("OptimismPortal", addr_);
 
         // Override the `OptimismPortal` contract to the deployed implementation. This is necessary
         // to check the `OptimismPortal` implementation alongside dependent contracts, which
@@ -613,12 +614,12 @@ contract Deploy is Deployer {
             _data: abi.encodeCall(
                 IL2OutputOracle.initialize,
                 (
-                    address(0),
-                    address(0),
                     cfg.l2OutputOracleSubmissionInterval(),
                     cfg.l2BlockTime(),
                     cfg.l2OutputOracleStartingBlockNumber(),
                     cfg.l2OutputOracleStartingTimestamp(),
+                    cfg.l2OutputOracleProposer(),
+                    cfg.l2OutputOracleChallenger(),
                     cfg.finalizationPeriodSeconds()
                 )
             )

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -52,7 +52,6 @@ import { ISP1Verifier } from "interfaces/vendor/sp1/ISP1Verifier.sol";
 import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
 import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
 import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
-import { IKromaGovernanceToken } from "interfaces/governance/IKromaGovernanceToken.sol";
 
 // See DeploySuperchain.s.sol for detailed comments on the script architecture used here.
 contract DeployImplementationsInput is BaseDeployIO {
@@ -63,12 +62,6 @@ contract DeployImplementationsInput is BaseDeployIO {
     uint256 internal _proofMaturityDelaySeconds;
     uint256 internal _disputeGameFinalityDelaySeconds;
     uint256 internal _mipsVersion;
-
-    // [Kroma: START]
-    /// @notice Deploy configs for ZKProofVerifier.
-    ISP1Verifier internal _sp1Verifier;
-    bytes32 internal _vKey;
-    // [Kroma: END]
 
     // This is used in opcm to signal which version of the L1 smart contracts is deployed.
     // It takes the format of `op-contracts/v*.*.*`.
@@ -112,17 +105,11 @@ contract DeployImplementationsInput is BaseDeployIO {
         require(_addr != address(0), "DeployImplementationsInput: cannot set zero address");
         if (_sel == this.superchainConfigProxy.selector) _superchainConfigProxy = ISuperchainConfig(_addr);
         else if (_sel == this.protocolVersionsProxy.selector) _protocolVersionsProxy = IProtocolVersions(_addr);
-        // [Kroma: START]
-        else if (_sel == this.sp1Verifier.selector) _sp1Verifier = ISP1Verifier(_addr);
-        // [Kroma: END]
         else revert("DeployImplementationsInput: unknown selector");
     }
 
     function set(bytes4 _sel, bytes32 _value) public {
         if (_sel == this.salt.selector) _salt = _value;
-        // [Kroma: START]
-        else if (_sel == this.vKey.selector) _vKey = _value;
-        // [Kroma: END]
         else revert("DeployImplementationsInput: unknown selector");
     }
 
@@ -183,17 +170,6 @@ contract DeployImplementationsInput is BaseDeployIO {
         require(address(_protocolVersionsProxy) != address(0), "DeployImplementationsInput: not set");
         return _protocolVersionsProxy;
     }
-
-    function sp1Verifier() public view returns (ISP1Verifier) {
-        require(address(_sp1Verifier) != address(0), "DeployImplementationsInput: sp1Verifier not set");
-        return _sp1Verifier;
-    }
-
-    function vKey() public view returns (bytes32) {
-        require(_vKey != bytes32(0), "DeployImplementationsInput: vKey not set");
-        return _vKey;
-    }
-    // [Kroma: END]
 }
 
 contract DeployImplementationsOutput is BaseDeployIO {
@@ -208,18 +184,6 @@ contract DeployImplementationsOutput is BaseDeployIO {
     IL1StandardBridge internal _l1StandardBridgeImpl;
     IOptimismMintableERC20Factory internal _optimismMintableERC20FactoryImpl;
     IDisputeGameFactory internal _disputeGameFactoryImpl;
-
-    // [Kroma: START]
-    IAssetManager internal _assetManagerImpl;
-    IColosseum internal _colosseumImpl;
-    IL2OutputOracle internal _l2OutputOracleImpl;
-    ISecurityCouncil internal _securityCouncilImpl;
-    ISecurityCouncilToken internal _securityCouncilTokenImpl;
-    ITimeLock internal _timeLockImpl;
-    IUpgradeGovernor internal _upgradeGovernorImpl;
-    IValidatorManager internal _validatorManagerImpl;
-    IZKProofVerifier internal _zkProofVerifierImpl;
-    // [Kroma: END]
 
     function set(bytes4 _sel, address _addr) public {
         require(_addr != address(0), "DeployImplementationsOutput: cannot set zero address");
@@ -236,17 +200,6 @@ contract DeployImplementationsOutput is BaseDeployIO {
         else if (_sel == this.l1StandardBridgeImpl.selector) _l1StandardBridgeImpl = IL1StandardBridge(payable(_addr));
         else if (_sel == this.optimismMintableERC20FactoryImpl.selector) _optimismMintableERC20FactoryImpl = IOptimismMintableERC20Factory(_addr);
         else if (_sel == this.disputeGameFactoryImpl.selector) _disputeGameFactoryImpl = IDisputeGameFactory(_addr);
-        // [Kroma: START]
-        else if (_sel == this.assetManagerImpl.selector) _assetManagerImpl = IAssetManager(_addr);
-        else if (_sel == this.colosseumImpl.selector) _colosseumImpl = IColosseum(_addr);
-        else if (_sel == this.l2OutputOracleImpl.selector) _l2OutputOracleImpl = IL2OutputOracle(_addr);
-        else if (_sel == this.securityCouncilImpl.selector) _securityCouncilImpl = ISecurityCouncil(_addr);
-        else if (_sel == this.securityCouncilTokenImpl.selector) _securityCouncilTokenImpl = ISecurityCouncilToken(_addr);
-        else if (_sel == this.timeLockImpl.selector) _timeLockImpl = ITimeLock(payable(_addr));
-        else if (_sel == this.upgradeGovernorImpl.selector) _upgradeGovernorImpl = IUpgradeGovernor(payable(_addr));
-        else if (_sel == this.validatorManagerImpl.selector) _validatorManagerImpl = IValidatorManager(_addr);
-        else if (_sel == this.zkProofVerifierImpl.selector) _zkProofVerifierImpl = IZKProofVerifier(_addr);
-        // [Kroma: END]
         else revert("DeployImplementationsOutput: unknown selector");
         // forgefmt: disable-end
     }
@@ -271,18 +224,7 @@ contract DeployImplementationsOutput is BaseDeployIO {
             address(this.disputeGameFactoryImpl())
         );
 
-        address[] memory addrs3 = Solarray.addresses(
-            address(this.assetManagerImpl()),
-            address(this.colosseumImpl()),
-            address(this.securityCouncilImpl()),
-            address(this.securityCouncilTokenImpl()),
-            address(this.timeLockImpl()),
-            address(this.upgradeGovernorImpl()),
-            address(this.validatorManagerImpl()),
-            address(this.zkProofVerifierImpl())
-        );
-
-        DeployUtils.assertValidContractAddresses(Solarray.extend(Solarray.extend(addrs1, addrs2), addrs3));
+        DeployUtils.assertValidContractAddresses(Solarray.extend(addrs1, addrs2));
 
         assertValidDeploy(_dii);
     }
@@ -342,58 +284,6 @@ contract DeployImplementationsOutput is BaseDeployIO {
         return _disputeGameFactoryImpl;
     }
 
-    // [Kroma: START]
-    function assetManagerImpl() public view returns (IAssetManager) {
-        require(address(_assetManagerImpl) != address(0), "DeployImplementationsOutput: assetManagerImpl not set");
-        return _assetManagerImpl;
-    }
-
-    function colosseumImpl() public view returns (IColosseum) {
-        require(address(_colosseumImpl) != address(0), "DeployImplementationsOutput: colosseumImpl not set");
-        return _colosseumImpl;
-    }
-
-    function l2OutputOracleImpl() public view returns (IL2OutputOracle) {
-        require(address(_l2OutputOracleImpl) != address(0), "DeployImplementationsOutput: l2OutputOracleImpl not set");
-        return _l2OutputOracleImpl;
-    }
-
-    function securityCouncilImpl() public view returns (ISecurityCouncil) {
-        require(address(_securityCouncilImpl) != address(0), "DeployImplementationsOutput: securityCouncilImpl not set");
-        return _securityCouncilImpl;
-    }
-
-    function securityCouncilTokenImpl() public view returns (ISecurityCouncilToken) {
-        require(
-            address(_securityCouncilTokenImpl) != address(0),
-            "DeployImplementationsOutput: securityCouncilTokenImpl not set"
-        );
-        return _securityCouncilTokenImpl;
-    }
-
-    function timeLockImpl() public view returns (ITimeLock) {
-        require(address(_timeLockImpl) != address(0), "DeployImplementationsOutput: timeLockImpl not set");
-        return _timeLockImpl;
-    }
-
-    function upgradeGovernorImpl() public view returns (IUpgradeGovernor) {
-        require(address(_upgradeGovernorImpl) != address(0), "DeployImplementationsOutput: upgradeGovernorImpl not set");
-        return _upgradeGovernorImpl;
-    }
-
-    function validatorManagerImpl() public view returns (IValidatorManager) {
-        require(
-            address(_validatorManagerImpl) != address(0), "DeployImplementationsOutput: validatorManagerImpl not set"
-        );
-        return _validatorManagerImpl;
-    }
-
-    function zkProofVerifierImpl() public view returns (IZKProofVerifier) {
-        require(address(_zkProofVerifierImpl) != address(0), "DeployImplementationsOutput: zkProofVerifierImpl not set");
-        return _zkProofVerifierImpl;
-    }
-    // [Kroma: END]
-
     // -------- Deployment Assertions --------
     function assertValidDeploy(DeployImplementationsInput _dii) public view {
         assertValidDelayedWETHImpl(_dii);
@@ -407,16 +297,6 @@ contract DeployImplementationsOutput is BaseDeployIO {
         assertValidOptimismPortalImpl(_dii);
         assertValidPreimageOracleSingleton(_dii);
         assertValidSystemConfigImpl(_dii);
-        // [Kroma: START]
-        assertValidAssetManager(_dii);
-        assertValidColosseum(_dii);
-        assertValidSecurityCouncil(_dii);
-        assertValidSecurityCouncilToken(_dii);
-        assertValidTimeLock(_dii);
-        assertValidUpgradeGovernor(_dii);
-        assertValidValidatorManager(_dii);
-        assertValidZKProofVerifier(_dii);
-        // [Kroma: END]
     }
 
     function assertValidOpcm(DeployImplementationsInput _dii) internal view {
@@ -554,130 +434,6 @@ contract DeployImplementationsOutput is BaseDeployIO {
 
         require(address(factory.owner()) == address(0), "DG-10");
     }
-
-    // [Kroma: START]
-    function assertValidAssetManager(DeployImplementationsInput) public view {
-        IAssetManager assetManager = assetManagerImpl();
-        uint256 slot = uint256(keccak256("initializable.dynamic.initialized")) - 1;
-        DeployUtils.assertInitialized({ _contractAddress: address(assetManager), _slot: slot, _offset: 0 });
-
-        require(address(assetManager.ASSET_TOKEN()) == address(0), "ASSETMGR-10");
-        require(address(assetManager.assetToken()) == address(0), "ASSETMGR-20");
-        require(address(assetManager.KGH()) == address(0), "ASSETMGR-30");
-        require(address(assetManager.kgh()) == address(0), "ASSETMGR-40");
-        require(address(assetManager.SECURITY_COUNCIL()) == address(0), "ASSETMGR-50");
-        require(address(assetManager.securityCouncil()) == address(0), "ASSETMGR-60");
-        require(address(assetManager.VALIDATOR_REWARD_VAULT()) == address(0), "ASSETMGR-70");
-        require(address(assetManager.validatorRewardVault()) == address(0), "ASSETMGR-80");
-        require(address(assetManager.VALIDATOR_MANAGER()) == address(0), "ASSETMGR-90");
-        require(address(assetManager.validatorManager()) == address(0), "ASSETMGR-100");
-        require(assetManager.MIN_DELEGATION_PERIOD() == 0, "ASSETMGR-110");
-        require(assetManager.minDelegationPeriod() == 0, "ASSETMGR-120");
-        require(assetManager.BOND_AMOUNT() == 0, "ASSETMGR-130");
-        require(assetManager.bondAmount() == 0, "ASSETMGR-140");
-    }
-
-    function assertValidColosseum(DeployImplementationsInput) public view {
-        IColosseum colosseum = colosseumImpl();
-
-        DeployUtils.assertInitialized({ _contractAddress: address(colosseum), _slot: 0, _offset: 0 });
-
-        require(address(colosseum.L2_ORACLE()) == address(0), "COLOSSEUM-10");
-        require(address(colosseum.l2Oracle()) == address(0), "COLOSSEUM-20");
-        require(address(colosseum.ZK_PROOF_VERIFIER()) == address(0), "COLOSSEUM-30");
-        require(address(colosseum.zkProofVerifier()) == address(0), "COLOSSEUM-40");
-        require(colosseum.L2_ORACLE_SUBMISSION_INTERVAL() == 0, "COLOSSEUM-50");
-        require(colosseum.l2OracleSubmissionInterval() == 0, "COLOSSEUM-60");
-        require(colosseum.CREATION_PERIOD_SECONDS() == 0, "COLOSSEUM-70");
-        require(colosseum.creationPeriodSeconds() == 0, "COLOSSEUM-80");
-        require(colosseum.BISECTION_TIMEOUT() == 0, "COLOSSEUM-90");
-        require(colosseum.bisectionTimeout() == 0, "COLOSSEUM-100");
-        require(colosseum.PROVING_TIMEOUT() == 0, "COLOSSEUM-110");
-        require(colosseum.provingTimeout() == 0, "COLOSSEUM-120");
-        require(colosseum.segmentsLengths(0) == 0, "COLOSSEUM-130");
-        require(address(colosseum.SECURITY_COUNCIL()) == address(0), "COLOSSEUM-140");
-        require(address(colosseum.securityCouncil()) == address(0), "COLOSSEUM-150");
-    }
-
-    function assertValidSecurityCouncil(DeployImplementationsInput) public view {
-        ISecurityCouncil securityCouncil = securityCouncilImpl();
-
-        DeployUtils.assertInitialized({ _contractAddress: address(securityCouncil), _slot: 0, _offset: 0 });
-
-        require(securityCouncil.COLOSSEUM() == address(0), "SC-10");
-        require(securityCouncil.colosseum() == address(0), "SC-20");
-        require(address(securityCouncil.GOVERNOR()) == address(0), "SC-30");
-        require(address(securityCouncil.governor()) == address(0), "SC-40");
-    }
-
-    function assertValidSecurityCouncilToken(DeployImplementationsInput) public view {
-        ISecurityCouncilToken securityCouncilToken = securityCouncilTokenImpl();
-
-        DeployUtils.assertInitialized({ _contractAddress: address(securityCouncilToken), _slot: 0, _offset: 0 });
-
-        require(address(securityCouncilToken.owner()) == address(0), "SCT-10");
-    }
-
-    function assertValidTimeLock(DeployImplementationsInput) public view {
-        ITimeLock timeLock = timeLockImpl();
-
-        DeployUtils.assertInitialized({ _contractAddress: address(timeLock), _slot: 0, _offset: 0 });
-
-        require(timeLock.getMinDelay() == 0, "TL-10");
-    }
-
-    function assertValidUpgradeGovernor(DeployImplementationsInput) public view {
-        IUpgradeGovernor upgradeGovernor = upgradeGovernorImpl();
-
-        DeployUtils.assertInitialized({ _contractAddress: address(upgradeGovernor), _slot: 0, _offset: 0 });
-
-        require(address(upgradeGovernor.token()) == address(0), "UG-10");
-        require(address(upgradeGovernor.timelock()) == address(0), "UG-20");
-        require(upgradeGovernor.votingDelay() == 0, "UG-30");
-        require(upgradeGovernor.votingPeriod() == 0, "UG-40");
-        require(upgradeGovernor.proposalThreshold() == 0, "UG-50");
-        require(upgradeGovernor.quorumNumerator() == 0, "UG-60");
-    }
-
-    function assertValidValidatorManager(DeployImplementationsInput) public view {
-        IValidatorManager validatorManager = validatorManagerImpl();
-
-        uint256 slot = uint256(keccak256("initializable.dynamic.initialized")) - 1;
-        DeployUtils.assertInitialized({ _contractAddress: address(validatorManager), _slot: slot, _offset: 0 });
-
-        require(address(validatorManager.L2_ORACLE()) == address(0), "VM-10");
-        require(address(validatorManager.l2Oracle()) == address(0), "VM-20");
-        require(address(validatorManager.ASSET_MANAGER()) == address(0), "VM-30");
-        require(address(validatorManager.assetManager()) == address(0), "VM-40");
-        require(validatorManager.TRUSTED_VALIDATOR() == address(0), "VM-50");
-        require(validatorManager.trustedValidator() == address(0), "VM-60");
-        require(validatorManager.COMMISSION_CHANGE_DELAY_SECONDS() == 0, "VM-70");
-        require(validatorManager.commissionChangeDelaySeconds() == 0, "VM-80");
-        require(validatorManager.ROUND_DURATION_SECONDS() == 0, "VM-90");
-        require(validatorManager.roundDurationSeconds() == 0, "VM-100");
-        require(validatorManager.SOFT_JAIL_PERIOD_SECONDS() == 0, "VM-110");
-        require(validatorManager.softJailPeriodSeconds() == 0, "VM-120");
-        require(validatorManager.HARD_JAIL_PERIOD_SECONDS() == 0, "VM-130");
-        require(validatorManager.hardJailPeriodSeconds() == 0, "VM-140");
-        require(validatorManager.JAIL_THRESHOLD() == 0, "VM-150");
-        require(validatorManager.jailThreshold() == 0, "VM-160");
-        require(validatorManager.MAX_OUTPUT_FINALIZATIONS() == 0, "VM-170");
-        require(validatorManager.maxOutputFinalizations() == 0, "VM-180");
-        require(validatorManager.BASE_REWARD() == 0, "VM-190");
-        require(validatorManager.baseReward() == 0, "VM-200");
-        require(validatorManager.MIN_REGISTER_AMOUNT() == 0, "VM-210");
-        require(validatorManager.minRegisterAmount() == 0, "VM-220");
-        require(validatorManager.MIN_ACTIVATE_AMOUNT() == 0, "VM-230");
-        require(validatorManager.minActiveAmount() == 0, "VM-240");
-    }
-
-    function assertValidZKProofVerifier(DeployImplementationsInput _dii) public view {
-        IZKProofVerifier zkProofVerifier = zkProofVerifierImpl();
-
-        require(address(zkProofVerifier.sp1Verifier()) == address(_dii.sp1Verifier()), "ZKP-10");
-        require(zkProofVerifier.zkVmProgramVKey() == _dii.vKey(), "ZKP-20");
-    }
-    // [Kroma: END]
 }
 
 contract DeployImplementations is Script {
@@ -697,17 +453,6 @@ contract DeployImplementations is Script {
         deployPreimageOracleSingleton(_dii, _dio);
         deployMipsSingleton(_dii, _dio);
         deployDisputeGameFactoryImpl(_dii, _dio);
-
-        // [Kroma: START]
-        deployAssetManagerImpl(_dii, _dio);
-        deployColosseumImpl(_dii, _dio);
-        deploySecurityCouncilImpl(_dii, _dio);
-        deploySecurityCouncilTokenImpl(_dii, _dio);
-        deployTimeLockImpl(_dii, _dio);
-        deployUpgradeGovernorImpl(_dii, _dio);
-        deployValidatorManagerImpl(_dii, _dio);
-        deployZKProofVerifierImpl(_dii, _dio);
-        // [Kroma: END]
 
         // Deploy the OP Contracts Manager with the new implementations set.
         deployOPContractsManager(_dii, _dio);
@@ -741,18 +486,8 @@ contract DeployImplementations is Script {
             l1StandardBridgeImpl: address(_dio.l1StandardBridgeImpl()),
             disputeGameFactoryImpl: address(_dio.disputeGameFactoryImpl()),
             delayedWETHImpl: address(_dio.delayedWETHImpl()),
-            mipsImpl: address(_dio.mipsSingleton()),
-            // [Kroma: START]
-            assetManagerImpl: address(_dio.assetManagerImpl()),
-            colosseumImpl: address(_dio.colosseumImpl()),
-            securityCouncilImpl: address(_dio.securityCouncilImpl()),
-            securityCouncilTokenImpl: address(_dio.securityCouncilTokenImpl()),
-            timeLockImpl: address(_dio.timeLockImpl()),
-            upgradeGovernorImpl: address(_dio.upgradeGovernorImpl()),
-            validatorManagerImpl: address(_dio.validatorManagerImpl()),
-            zkProofVerifierImpl: address(_dio.zkProofVerifierImpl())
+            mipsImpl: address(_dio.mipsSingleton())
         });
-        // [Kroma: END]
 
         vm.broadcast(msg.sender);
         opcm_ = new OPContractsManager(
@@ -1130,225 +865,6 @@ contract DeployImplementations is Script {
         _dio.set(_dio.disputeGameFactoryImpl.selector, address(impl));
     }
 
-    // [Kroma: START]
-    function deployAssetManagerImpl(DeployImplementationsInput _dii, DeployImplementationsOutput _dio) public virtual {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "assetManager";
-        IAssetManager impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = IAssetManager(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = IAssetManager(
-                DeployUtils.create1({
-                    _name: "AssetManager",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IAssetManager.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "AssetManagerImpl");
-        _dio.set(_dio.assetManagerImpl.selector, address(impl));
-    }
-
-    function deployColosseumImpl(DeployImplementationsInput _dii, DeployImplementationsOutput _dio) public virtual {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "colosseum";
-        IColosseum impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = IColosseum(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = IColosseum(
-                DeployUtils.create1({
-                    _name: "Colosseum",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IColosseum.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "ColosseumImpl");
-        _dio.set(_dio.colosseumImpl.selector, address(impl));
-    }
-
-    function deploySecurityCouncilImpl(
-        DeployImplementationsInput _dii,
-        DeployImplementationsOutput _dio
-    )
-        public
-        virtual
-    {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "security_council";
-        ISecurityCouncil impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = ISecurityCouncil(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = ISecurityCouncil(
-                DeployUtils.create1({
-                    _name: "SecurityCouncil",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(ISecurityCouncil.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "SecurityCouncilImpl");
-        _dio.set(_dio.securityCouncilImpl.selector, address(impl));
-    }
-
-    function deploySecurityCouncilTokenImpl(
-        DeployImplementationsInput _dii,
-        DeployImplementationsOutput _dio
-    )
-        public
-        virtual
-    {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "security_council_token";
-        ISecurityCouncilToken impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = ISecurityCouncilToken(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = ISecurityCouncilToken(
-                DeployUtils.create1({
-                    _name: "SecurityCouncilToken",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(ISecurityCouncilToken.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "SecurityCouncilTokenImpl");
-        _dio.set(_dio.securityCouncilTokenImpl.selector, address(impl));
-    }
-
-    function deployTimeLockImpl(DeployImplementationsInput _dii, DeployImplementationsOutput _dio) public virtual {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "time_lock";
-        ITimeLock impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = ITimeLock(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = ITimeLock(
-                DeployUtils.create1({
-                    _name: "TimeLock",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(ITimeLock.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "TimeLockImpl");
-        _dio.set(_dio.timeLockImpl.selector, address(impl));
-    }
-
-    function deployUpgradeGovernorImpl(
-        DeployImplementationsInput _dii,
-        DeployImplementationsOutput _dio
-    )
-        public
-        virtual
-    {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "upgrade_governor";
-        IUpgradeGovernor impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = IUpgradeGovernor(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = IUpgradeGovernor(
-                DeployUtils.create1({
-                    _name: "UpgradeGovernor",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IUpgradeGovernor.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "UpgradeGovernorImpl");
-        _dio.set(_dio.upgradeGovernorImpl.selector, address(impl));
-    }
-
-    function deployValidatorManagerImpl(
-        DeployImplementationsInput _dii,
-        DeployImplementationsOutput _dio
-    )
-        public
-        virtual
-    {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "validator_manager";
-        IValidatorManager impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = IValidatorManager(payable(existingImplementation));
-        } else {
-            vm.broadcast(msg.sender);
-            impl = IValidatorManager(
-                DeployUtils.create1({
-                    _name: "ValidatorManager",
-                    _args: DeployUtils.encodeConstructor(abi.encodeCall(IValidatorManager.__constructor__, ()))
-                })
-            );
-        }
-
-        vm.label(address(impl), "ValidatorManagerImpl");
-        _dio.set(_dio.validatorManagerImpl.selector, address(impl));
-    }
-
-    function deployZKProofVerifierImpl(
-        DeployImplementationsInput _dii,
-        DeployImplementationsOutput _dio
-    )
-        public
-        virtual
-    {
-        string memory release = _dii.l1ContractsRelease();
-        string memory stdVerToml = _dii.standardVersionsToml();
-        string memory contractName = "zk_proof_verifier";
-        IZKProofVerifier impl;
-
-        address existingImplementation = getReleaseAddress(release, contractName, stdVerToml);
-        if (existingImplementation != address(0)) {
-            impl = IZKProofVerifier(payable(existingImplementation));
-        } else {
-            vm.startBroadcast(msg.sender);
-            impl = IZKProofVerifier(
-                DeployUtils.create1({
-                    _name: "ZKProofVerifier",
-                    _args: DeployUtils.encodeConstructor(
-                        abi.encodeCall(IZKProofVerifier.__constructor__, (_dii.sp1Verifier(), _dii.vKey()))
-                    )
-                })
-            );
-            vm.stopBroadcast();
-        }
-
-        vm.label(address(impl), "ZKProofVerifierImpl");
-        _dio.set(_dio.zkProofVerifierImpl.selector, address(impl));
-    }
-    // [Kroma: END]
-
     // -------- Utilities --------
 
     function etchIOContracts() public returns (DeployImplementationsInput dii_, DeployImplementationsOutput dio_) {
@@ -1470,18 +986,8 @@ contract DeployImplementationsInterop is DeployImplementations {
             l1StandardBridgeImpl: address(_dio.l1StandardBridgeImpl()),
             disputeGameFactoryImpl: address(_dio.disputeGameFactoryImpl()),
             delayedWETHImpl: address(_dio.delayedWETHImpl()),
-            mipsImpl: address(_dio.mipsSingleton()),
-            // [Kroma: START]
-            assetManagerImpl: address(_dio.assetManagerImpl()),
-            colosseumImpl: address(_dio.colosseumImpl()),
-            securityCouncilImpl: address(_dio.securityCouncilImpl()),
-            securityCouncilTokenImpl: address(_dio.securityCouncilTokenImpl()),
-            timeLockImpl: address(_dio.timeLockImpl()),
-            upgradeGovernorImpl: address(_dio.upgradeGovernorImpl()),
-            validatorManagerImpl: address(_dio.validatorManagerImpl()),
-            zkProofVerifierImpl: address(_dio.zkProofVerifierImpl())
+            mipsImpl: address(_dio.mipsSingleton())
         });
-        // [Kroma: END]
 
         vm.broadcast(msg.sender);
         opcm_ = new OPContractsManagerInterop(

--- a/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployImplementations.s.sol
@@ -35,24 +35,6 @@ import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
 import { Solarray } from "scripts/libraries/Solarray.sol";
 import { BaseDeployIO } from "scripts/deploy/BaseDeployIO.sol";
 
-import { AssetManager } from "src/L1/AssetManager.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
-import { SystemConfig } from "src/L1/SystemConfig.sol";
-import { ZKProofVerifier } from "src/L1/ZKProofVerifier.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
-import { IColosseum } from "interfaces/L1/IColosseum.sol";
-import { IOptimismPortal } from "interfaces/L1/IOptimismPortal.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
-import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
-import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
-import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
-import { ISP1Verifier } from "interfaces/vendor/sp1/ISP1Verifier.sol";
-import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
-import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
-import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
-
 // See DeploySuperchain.s.sol for detailed comments on the script architecture used here.
 contract DeployImplementationsInput is BaseDeployIO {
     bytes32 internal _salt;

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPCM.s.sol
@@ -36,18 +36,6 @@ contract DeployOPCMInput is BaseDeployIO {
     address internal _delayedWETHImpl;
     address internal _mipsImpl;
 
-    // [Kroma: START]
-    address internal _assetManagerImpl;
-    address internal _colosseumImpl;
-    address internal _l2OutputOracleImpl;
-    address internal _securityCouncilImpl;
-    address internal _securityCouncilTokenImpl;
-    address internal _timeLockImpl;
-    address internal _upgradeGovernorImpl;
-    address internal _validatorManagerImpl;
-    address internal _zkProofVerifierImpl;
-    // [Kroma: END]
-
     // Setter for address type
     function set(bytes4 _sel, address _addr) public {
         require(_addr != address(0), "DeployOPCMInput: cannot set zero address");
@@ -71,17 +59,6 @@ contract DeployOPCMInput is BaseDeployIO {
         else if (_sel == this.disputeGameFactoryImpl.selector) _disputeGameFactoryImpl = _addr;
         else if (_sel == this.delayedWETHImpl.selector) _delayedWETHImpl = _addr;
         else if (_sel == this.mipsImpl.selector) _mipsImpl = _addr;
-        // [Kroma: START]
-        else if (_sel == this.assetManagerImpl.selector) _assetManagerImpl = _addr;
-        else if (_sel == this.colosseumImpl.selector) _colosseumImpl = _addr;
-        else if (_sel == this.l2OutputOracleImpl.selector) _l2OutputOracleImpl = _addr;
-        else if (_sel == this.securityCouncilImpl.selector) _securityCouncilImpl = _addr;
-        else if (_sel == this.securityCouncilTokenImpl.selector) _securityCouncilTokenImpl = _addr;
-        else if (_sel == this.timeLockImpl.selector) _timeLockImpl = payable(_addr);
-        else if (_sel == this.upgradeGovernorImpl.selector) _upgradeGovernorImpl = payable(_addr);
-        else if (_sel == this.validatorManagerImpl.selector) _validatorManagerImpl = _addr;
-        else if (_sel == this.zkProofVerifierImpl.selector) _zkProofVerifierImpl = _addr;
-        // [Kroma: END]
         else revert("DeployOPCMInput: unknown selector");
     }
 
@@ -192,58 +169,6 @@ contract DeployOPCMInput is BaseDeployIO {
         require(_mipsImpl != address(0), "DeployOPCMInput: not set");
         return _mipsImpl;
     }
-
-    // [Kroma: START]
-    function assetManagerImpl() public view returns (address) {
-        require(address(_assetManagerImpl) != address(0), "DeployImplementationsOutput: assetManagerImpl not set");
-        return _assetManagerImpl;
-    }
-
-    function colosseumImpl() public view returns (address) {
-        require(address(_colosseumImpl) != address(0), "DeployImplementationsOutput: colosseumImpl not set");
-        return _colosseumImpl;
-    }
-
-    function l2OutputOracleImpl() public view returns (address) {
-        require(address(_l2OutputOracleImpl) != address(0), "DeployImplementationsOutput: l2OutputOracleImpl not set");
-        return _l2OutputOracleImpl;
-    }
-
-    function securityCouncilImpl() public view returns (address) {
-        require(address(_securityCouncilImpl) != address(0), "DeployImplementationsOutput: securityCouncilImpl not set");
-        return _securityCouncilImpl;
-    }
-
-    function securityCouncilTokenImpl() public view returns (address) {
-        require(
-            address(_securityCouncilTokenImpl) != address(0),
-            "DeployImplementationsOutput: securityCouncilTokenImpl not set"
-        );
-        return _securityCouncilTokenImpl;
-    }
-
-    function timeLockImpl() public view returns (address) {
-        require(address(_timeLockImpl) != address(0), "DeployImplementationsOutput: timeLockImpl not set");
-        return _timeLockImpl;
-    }
-
-    function upgradeGovernorImpl() public view returns (address) {
-        require(address(_upgradeGovernorImpl) != address(0), "DeployImplementationsOutput: upgradeGovernorImpl not set");
-        return _upgradeGovernorImpl;
-    }
-
-    function validatorManagerImpl() public view returns (address) {
-        require(
-            address(_validatorManagerImpl) != address(0), "DeployImplementationsOutput: validatorManagerImpl not set"
-        );
-        return _validatorManagerImpl;
-    }
-
-    function zkProofVerifierImpl() public view returns (address) {
-        require(address(_zkProofVerifierImpl) != address(0), "DeployImplementationsOutput: zkProofVerifierImpl not set");
-        return _zkProofVerifierImpl;
-    }
-    // [Kroma: END]
 }
 
 contract DeployOPCMOutput is BaseDeployIO {
@@ -284,17 +209,7 @@ contract DeployOPCM is Script {
             l1StandardBridgeImpl: address(_doi.l1StandardBridgeImpl()),
             disputeGameFactoryImpl: address(_doi.disputeGameFactoryImpl()),
             delayedWETHImpl: address(_doi.delayedWETHImpl()),
-            mipsImpl: address(_doi.mipsImpl()),
-            // [Kroma: START]
-            assetManagerImpl: address(_doi.assetManagerImpl()),
-            colosseumImpl: address(_doi.colosseumImpl()),
-            securityCouncilImpl: address(_doi.securityCouncilImpl()),
-            securityCouncilTokenImpl: address(_doi.securityCouncilTokenImpl()),
-            timeLockImpl: address(_doi.timeLockImpl()),
-            upgradeGovernorImpl: address(_doi.upgradeGovernorImpl()),
-            validatorManagerImpl: address(_doi.validatorManagerImpl()),
-            zkProofVerifierImpl: address(_doi.zkProofVerifierImpl())
-            // [Kroma: END]
+            mipsImpl: address(_doi.mipsImpl())
         });
 
         OPContractsManager opcm_ = deployOPCM(

--- a/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployOPChain.s.sol
@@ -35,9 +35,6 @@ import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
 
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
-
 contract DeployOPChainInput is BaseDeployIO {
     address internal _opChainProxyAdminOwner;
     address internal _systemConfigOwner;
@@ -62,41 +59,6 @@ contract DeployOPChainInput is BaseDeployIO {
     Duration internal _disputeClockExtension;
     Duration internal _disputeMaxClockDuration;
     bool internal _allowCustomDisputeParameters;
-
-    // [Kroma: START]
-    /// @notice Deploy configs for AssetManager.
-    IERC721 internal _kgh;
-    address internal _vault;
-    uint128 internal _minDelegationPeriod;
-    uint128 internal _bondAmount;
-
-    /// @notice Deploy configs for Colosseum.
-    IL2OutputOracle internal _l2OutputOracle;
-    uint256 internal _submissionInterval;
-    uint256 internal _creationPeriodSeconds;
-    uint256 internal _bisectionTimeout;
-    uint256 internal _provingTimeout;
-    uint256[] internal _segmentsLengths;
-
-    /// @notice Deploy configs for SecurityCouncil.
-    uint256 internal _timeLockMinDelaySeconds;
-    /// @notice Deploy configs for UpgradeGovernor.
-    uint256 internal _initialVotingDelay;
-    uint256 internal _initialVotingPeriod;
-    uint256 internal _initialProposalThreshold;
-    uint256 internal _votesQuorumFraction;
-    /// @notice Deploy configs for ValidatorManager.
-    address internal _trustedValidator;
-    uint128 internal _minRegisterAmount;
-    uint128 internal _minActivateAmount;
-    uint128 internal _commissionChangeDelaySeconds;
-    uint128 internal _roundDurationSeconds;
-    uint128 internal _softJailPeriodSeconds;
-    uint128 internal _hardJailPeriodSeconds;
-    uint128 internal _jailThreshold;
-    uint128 internal _maxFinalizations;
-    uint128 internal _baseReward;
-    // [Kroma: END]
 
     function set(bytes4 _sel, address _addr) public {
         require(_addr != address(0), "DeployOPChainInput: cannot set zero address");
@@ -253,108 +215,6 @@ contract DeployOPChainInput is BaseDeployIO {
     function allowCustomDisputeParameters() public view returns (bool) {
         return _allowCustomDisputeParameters;
     }
-
-    // [Kroma: START]
-    function kgh() public view returns (IERC721) {
-        return _kgh;
-    }
-
-    function vault() public view returns (address) {
-        return _vault;
-    }
-
-    function minDelegationPeriod() public view returns (uint128) {
-        return _minDelegationPeriod;
-    }
-
-    function bondAmount() public view returns (uint128) {
-        return _bondAmount;
-    }
-
-    function l2OutputOracle() public view returns (IL2OutputOracle) {
-        return _l2OutputOracle;
-    }
-
-    function submissionInterval() public view returns (uint256) {
-        return _submissionInterval;
-    }
-
-    function creationPeriodSeconds() public view returns (uint256) {
-        return _creationPeriodSeconds;
-    }
-
-    function bisectionTimeout() public view returns (uint256) {
-        return _bisectionTimeout;
-    }
-
-    function provingTimeout() public view returns (uint256) {
-        return _provingTimeout;
-    }
-
-    function segmentsLengths() public view returns (uint256[] memory) {
-        return _segmentsLengths;
-    }
-
-    function timeLockMinDelaySeconds() public view returns (uint256) {
-        return _timeLockMinDelaySeconds;
-    }
-
-    function initialVotingDelay() public view returns (uint256) {
-        return _initialVotingDelay;
-    }
-
-    function initialVotingPeriod() public view returns (uint256) {
-        return _initialVotingPeriod;
-    }
-
-    function initialProposalThreshold() public view returns (uint256) {
-        return _initialProposalThreshold;
-    }
-
-    function votesQuorumFraction() public view returns (uint256) {
-        return _votesQuorumFraction;
-    }
-
-    function trustedValidator() public view returns (address) {
-        return _trustedValidator;
-    }
-
-    function minRegisterAmount() public view returns (uint128) {
-        return _minRegisterAmount;
-    }
-
-    function minActivateAmount() public view returns (uint128) {
-        return _minActivateAmount;
-    }
-
-    function commissionChangeDelaySeconds() public view returns (uint128) {
-        return _commissionChangeDelaySeconds;
-    }
-
-    function roundDurationSeconds() public view returns (uint128) {
-        return _roundDurationSeconds;
-    }
-
-    function softJailPeriodSeconds() public view returns (uint128) {
-        return _softJailPeriodSeconds;
-    }
-
-    function hardJailPeriodSeconds() public view returns (uint128) {
-        return _hardJailPeriodSeconds;
-    }
-
-    function jailThreshold() public view returns (uint128) {
-        return _jailThreshold;
-    }
-
-    function maxFinalizations() public view returns (uint128) {
-        return _maxFinalizations;
-    }
-
-    function baseReward() public view returns (uint128) {
-        return _baseReward;
-    }
-    // [Kroma: END]
 }
 
 contract DeployOPChainOutput is BaseDeployIO {
@@ -509,34 +369,7 @@ contract DeployOPChain is Script {
             disputeMaxGameDepth: _doi.disputeMaxGameDepth(),
             disputeSplitDepth: _doi.disputeSplitDepth(),
             disputeClockExtension: _doi.disputeClockExtension(),
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration(),
-            // [Kroma: START]
-            kgh: _doi.kgh(),
-            vault: _doi.vault(),
-            minDelegationPeriod: _doi.minDelegationPeriod(),
-            bondAmount: _doi.bondAmount(),
-            l2OutputOracle: _doi.l2OutputOracle(),
-            submissionInterval: _doi.submissionInterval(),
-            creationPeriodSeconds: _doi.creationPeriodSeconds(),
-            bisectionTimeout: _doi.bisectionTimeout(),
-            provingTimeout: _doi.provingTimeout(),
-            segmentsLengths: _doi.segmentsLengths(),
-            timeLockMinDelaySeconds: _doi.timeLockMinDelaySeconds(),
-            initialVotingDelay: _doi.initialVotingDelay(),
-            initialVotingPeriod: _doi.initialVotingPeriod(),
-            initialProposalThreshold: _doi.initialProposalThreshold(),
-            votesQuorumFraction: _doi.votesQuorumFraction(),
-            trustedValidator: _doi.trustedValidator(),
-            minRegisterAmount: _doi.minRegisterAmount(),
-            minActivateAmount: _doi.minActivateAmount(),
-            commissionChangeDelaySeconds: _doi.commissionChangeDelaySeconds(),
-            roundDurationSeconds: _doi.roundDurationSeconds(),
-            softJailPeriodSeconds: _doi.softJailPeriodSeconds(),
-            hardJailPeriodSeconds: _doi.hardJailPeriodSeconds(),
-            jailThreshold: _doi.jailThreshold(),
-            maxFinalizations: _doi.maxFinalizations(),
-            baseReward: _doi.baseReward()
-            // [Kroma: END]
+            disputeMaxClockDuration: _doi.disputeMaxClockDuration()
         });
 
         vm.broadcast(msg.sender);

--- a/packages/contracts-bedrock/scripts/deploy/Deployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deployer.sol
@@ -14,7 +14,6 @@ import { Process } from "scripts/libraries/Process.sol";
 abstract contract Deployer is Script, Artifacts {
     DeployConfig public constant cfg =
         DeployConfig(address(uint160(uint256(keccak256(abi.encode("optimism.deployconfig"))))));
-    string public constant saltMixer = "salt mixer";
 
     /// @notice Sets up the artifacts contract.
     function setUp() public virtual override {

--- a/packages/contracts-bedrock/scripts/deploy/KromaDeploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/KromaDeploy.s.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Testing
+import { Vm } from "forge-std/Vm.sol";
+import { console2 as console } from "forge-std/console2.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+import { EIP1967Helper } from "test/mocks/EIP1967Helper.sol";
+
+// Scripts
+import { Config } from "scripts/libraries/Config.sol";
+import { Deployer } from "scripts/deploy/Deployer.sol";
+import { KromaDeployer } from "./kroma/KromaDeployer.sol";
+import { KromaConfigBuilder } from "./kroma/KromaConfigBuilder.sol";
+import { KromaDeployInput, KromaDeployOutput } from "./kroma/KromaDeployTypes.sol";
+import { KromaPostDeployAssertions } from "./kroma/KromaChainAssertions.sol";
+import { Deploy } from "./Deploy.s.sol";
+import { DeployConfig } from "./DeployConfig.s.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { StorageSlot, ForgeArtifacts } from "scripts/libraries/ForgeArtifacts.sol";
+
+// Contracts
+import { KromaL2OutputOracle } from "src/L1/KromaL2OutputOracle.sol";
+
+// Interfaces
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { IProxyAdmin } from "../../interfaces/universal/IProxyAdmin.sol";
+import { IOptimismPortal } from "interfaces/L1/IOptimismPortal.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { ProxyAdmin } from "../../src/universal/ProxyAdmin.sol";
+
+/// @title KromaDeploy
+/// @notice Deployment script for all Kroma L1 contracts.
+contract KromaDeploy is Deployer {
+
+    ////////////////////////////////////////////////////////////////
+    //                        Modifiers                           //
+    ////////////////////////////////////////////////////////////////
+
+    modifier broadcast() {
+        vm.startBroadcast(msg.sender);
+        _;
+        vm.stopBroadcast();
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                        Accessors                           //
+    ////////////////////////////////////////////////////////////////
+
+    /// @notice The create2 salt used for deployment of the contract implementations.
+    ///         Using this helps to reduce config across networks as the implementation
+    ///         addresses will be the same across networks when deployed with create2.
+    function _implSalt() internal view returns (bytes32) {
+        return keccak256(bytes(Config.implSalt()));
+    }
+
+    /// @notice The CREATE2 salt to be used when deploying the proxy.
+    function _proxySalt() internal pure returns (string memory env_) {
+        env_ = string("kroma proxy");
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                    SetUp and Run                           //
+    ////////////////////////////////////////////////////////////////
+
+    function runWithStateDump() public {
+        console.log("== Starting kroma deployment with state dump ==");
+        vm.chainId(cfg.l1ChainID());
+        _run();
+        vm.dumpState(Config.stateDumpPath(""));
+    }
+
+    function run() public {
+        console.log("== Starting kroma deployment ==");
+        _run();
+    }
+
+    function _run() public {
+        // load stateDump & deployment addresses
+        vm.loadAllocs(Config.stateDumpPath(""));
+        string memory addresses = Config.deploymentOutfile();
+        if (bytes(addresses).length > 0) {
+            console.log("Loading addresses from: %s", addresses);
+            _loadAddresses(addresses);
+        }
+
+        console.log("-- [Step 0] Transfer ProxyAdmin ownership");
+        address finalSystemOwner = cfg.finalSystemOwner();
+        vm.startPrank(finalSystemOwner);
+        IProxyAdmin proxyAdmin = IProxyAdmin(mustGetAddress("ProxyAdmin"));
+        proxyAdmin.transferOwnership(msg.sender);
+        console.log("   > Ownership transferred to: %s", msg.sender);
+        vm.stopPrank();
+
+        console.log("-- [Step 1] Build deployment input");
+        KromaDeployInput memory kromaInput = KromaConfigBuilder.fromConfig(cfg);
+
+        console.log("-- [Step 2] Deploy implementation contracts");
+        KromaDeployOutput memory kromaOutput = KromaDeployer.deployImpls(deployImpl, kromaInput);
+
+        console.log("-- [Step 3] Deploy proxy contracts");
+        kromaOutput = KromaDeployer.deployProxies(deployERC1967Proxy, kromaOutput);
+
+        console.log("-- [Step 4] Deploy and initialize KromaL2OutputOracle");
+        deployERC1967Proxy("KromaL2OutputOracleProxy");
+        deployImpl("KromaL2OutputOracle", abi.encode());
+        initializeKromaL2OutputOracle();
+
+        console.log("-- [Step 5] Reset and initialize OptimismPortal");
+        // Since the contract is already deployed via deploy.s.sol, we reset the artifacts to start fresh.
+        removeDeploymentByName("OptimismPortal");
+        removeDeploymentByName("OptimismPortalProxy");
+        deployERC1967Proxy("OptimismPortalProxy");
+        deployImpl("OptimismPortal", abi.encode());
+        initializeOptimismPortal();
+
+        console.log("-- [Step 6] Upgrade and initialize all proxies");
+        KromaDeployer.upgradeAndInitializeProxies(proxyAdmin, kromaInput, mustGetAddress, vm);
+
+        console.log("-- [Step 7] Run post-deployment assertions");
+        KromaPostDeployAssertions.runPostDeployAssertions(kromaInput, kromaOutput, cfg, false);
+        KromaPostDeployAssertions.runPostDeployAssertions(kromaInput, kromaOutput, cfg, true);
+
+        console.log("== Deployment completed ==");
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                    Initialize Functions                    //
+    ////////////////////////////////////////////////////////////////
+
+    function initializeKromaL2OutputOracle() public broadcast {
+        console.log("Initializing KromaL2OutputOracle");
+        address l2OutputOracleProxy = mustGetAddress("KromaL2OutputOracleProxy");
+        address l2OutputOracle = mustGetAddress("KromaL2OutputOracle");
+        address validatorManagerProxy = mustGetAddress("ValidatorManagerProxy");
+        address colosseumProxy = mustGetAddress("ColosseumProxy");
+
+        IProxyAdmin proxyAdmin = IProxyAdmin(payable(mustGetAddress("ProxyAdmin")));
+        proxyAdmin.upgradeAndCall({
+            _proxy: payable(l2OutputOracleProxy),
+            _implementation: l2OutputOracle,
+            _data: abi.encodeCall(
+                IKromaL2OutputOracle.initialize,
+                (
+                    validatorManagerProxy,
+                    colosseumProxy,
+                    cfg.l2OutputOracleSubmissionInterval(),
+                    cfg.l2BlockTime(),
+                    cfg.l2OutputOracleStartingBlockNumber(),
+                    cfg.l2OutputOracleStartingTimestamp(),
+                    cfg.finalizationPeriodSeconds()
+                )
+            )
+        });
+    }
+
+    function initializeOptimismPortal() public broadcast {
+        console.log("Initializing OptimismPortal");
+        address optimismPortalProxy = mustGetAddress("OptimismPortalProxy");
+        address systemConfigProxy = mustGetAddress("SystemConfigProxy");
+        address superchainConfigProxy = mustGetAddress("SuperchainConfigProxy");
+        address optimismPortal = mustGetAddress("OptimismPortal");
+        address l2OutputOracleProxy = mustGetAddress("KromaL2OutputOracleProxy");
+
+        IProxyAdmin proxyAdmin = IProxyAdmin(payable(mustGetAddress("ProxyAdmin")));
+        proxyAdmin.upgradeAndCall({
+            _proxy: payable(optimismPortalProxy),
+            _implementation: optimismPortal,
+            _data: abi.encodeCall(
+                IOptimismPortal.initialize,
+                (
+                    IKromaL2OutputOracle(l2OutputOracleProxy),
+                    ISystemConfig(systemConfigProxy),
+                    ISuperchainConfig(superchainConfigProxy)
+                )
+            )
+        });
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                   Deployment Functions                     //
+    ////////////////////////////////////////////////////////////////
+
+    function deployImpl(string memory _name, bytes memory _data) internal returns (address) {
+        console.log("Deploying implementation: %s", _name);
+        vm.startBroadcast(msg.sender);
+        address impl = DeployUtils.create1({ _name: _name, _args: _data });
+        save(_name, impl);
+        vm.stopBroadcast();
+        vm.label(impl, _name);
+        return impl;
+    }
+
+    function deployERC1967Proxy(string memory _name) public returns (address addr_) {
+        console.log("Deploying proxy: %s", _name);
+        addr_ = deployERC1967ProxyWithOwner(_name, mustGetAddress("ProxyAdmin"));
+    }
+
+    function deployERC1967ProxyWithOwner(
+        string memory _name,
+        address _proxyOwner
+    )
+        public
+        broadcast
+        returns (address addr_)
+    {
+        console.log("Deploying proxy with owner %s: %s", _proxyOwner, _name);
+        IProxy proxy = IProxy(
+            DeployUtils.create2AndSave({
+                _save: this,
+                _salt: keccak256(abi.encode(_proxySalt(), _name)),
+                _name: "Proxy",
+                _nick: _name,
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IProxy.__constructor__, (_proxyOwner)))
+            })
+        );
+        require(EIP1967Helper.getAdmin(address(proxy)) == _proxyOwner);
+        addr_ = address(proxy);
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //                     Util Functions                         //
+    ////////////////////////////////////////////////////////////////
+
+    function removeDeploymentByName(string memory targetName) internal {
+        delete _namedDeployments[targetName];
+        uint256 len = _newDeployments.length;
+        for (uint256 i = 0; i < len; i++) {
+            if (keccak256(bytes(_newDeployments[i].name)) == keccak256(bytes(targetName))) {
+                // Shift elements to the left
+                for (uint256 j = i; j < len - 1; j++) {
+                    _newDeployments[j] = _newDeployments[j + 1];
+                }
+                _newDeployments.pop();
+                return;
+            }
+        }
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/KromaDeploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/KromaDeploy.s.sol
@@ -39,7 +39,6 @@ import { ProxyAdmin } from "../../src/universal/ProxyAdmin.sol";
 /// @title KromaDeploy
 /// @notice Deployment script for all Kroma L1 contracts.
 contract KromaDeploy is Deployer {
-
     ////////////////////////////////////////////////////////////////
     //                        Modifiers                           //
     ////////////////////////////////////////////////////////////////

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaChainAssertions.sol
@@ -56,7 +56,7 @@ library KromaChainAssertions {
     function assertValidAssetManager(
         KromaDeployInput memory input,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -104,7 +104,7 @@ library KromaChainAssertions {
     function assertValidColosseum(
         KromaDeployInput memory input,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -151,9 +151,9 @@ library KromaChainAssertions {
     }
 
     function assertValidSecurityCouncil(
-        KromaDeployInput memory input,
+        KromaDeployInput memory,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -178,9 +178,9 @@ library KromaChainAssertions {
     }
 
     function assertValidSecurityCouncilToken(
-        KromaDeployInput memory input,
+        KromaDeployInput memory,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -201,7 +201,7 @@ library KromaChainAssertions {
     function assertValidTimeLock(
         KromaDeployInput memory input,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -222,7 +222,7 @@ library KromaChainAssertions {
     function assertValidUpgradeGovernor(
         KromaDeployInput memory input,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -253,7 +253,7 @@ library KromaChainAssertions {
     function assertValidValidatorManager(
         KromaDeployInput memory input,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal
@@ -321,7 +321,7 @@ library KromaChainAssertions {
     function assertValidZKProofVerifier(
         KromaDeployInput memory input,
         KromaDeployOutput memory output,
-        DeployConfig _cfg,
+        DeployConfig,
         bool _isProxy
     )
         internal

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaChainAssertions.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaChainAssertions.sol
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Forge test utilities
+import { console2 as console } from "forge-std/console2.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Interfaces
+import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
+import { IColosseum } from "interfaces/L1/IColosseum.sol";
+import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
+import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
+import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
+import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
+
+// Scripts
+import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
+import { KromaDeployOutput, KromaDeployInput } from "scripts/deploy/kroma/KromaDeployTypes.sol";
+
+/// @title KromaPostDeployAssertions
+/// @notice Runs post-deployment validation checks on all Kroma contracts
+library KromaPostDeployAssertions {
+    /// @notice Verifies correctness of deployed contracts, both proxy and implementation
+    /// @param input Deployment input configuration
+    /// @param output Deployed contract addresses
+    /// @param cfg Deployment configuration
+    /// @param isProxy Whether the contracts are proxies
+    function runPostDeployAssertions(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig cfg,
+        bool isProxy
+    )
+        internal
+        view
+    {
+        console.log("[PostDeploy] Running assertions (isProxy: %s)", isProxy);
+        KromaChainAssertions.assertValidAssetManager(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidColosseum(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidSecurityCouncil(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidSecurityCouncilToken(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidTimeLock(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidUpgradeGovernor(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidValidatorManager(input, output, cfg, isProxy);
+        KromaChainAssertions.assertValidZKProofVerifier(input, output, cfg, isProxy);
+    }
+}
+
+/// @title KromaChainAssertions
+/// @notice Library containing assertion functions for verifying Kroma contract deployment state.
+library KromaChainAssertions {
+    function assertValidAssetManager(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] AssetManager (isProxy: %s)", _isProxy);
+        IAssetManager assetManager;
+        if (_isProxy) {
+            assetManager = IAssetManager(output.assetManagerProxy);
+            require(address(assetManager.ASSET_TOKEN()) == address(output.kromaGovernanceTokenProxy), "ASSETMGR-10");
+            require(address(assetManager.assetToken()) == address(output.kromaGovernanceTokenProxy), "ASSETMGR-20");
+            require(address(assetManager.KGH()) == address(input.kgh), "ASSETMGR-30");
+            require(address(assetManager.kgh()) == address(input.kgh), "ASSETMGR-40");
+            require(address(assetManager.SECURITY_COUNCIL()) == address(output.securityCouncilProxy), "ASSETMGR-50");
+            require(address(assetManager.securityCouncil()) == address(output.securityCouncilProxy), "ASSETMGR-60");
+            require(address(assetManager.VALIDATOR_REWARD_VAULT()) == address(input.vault), "ASSETMGR-70");
+            require(address(assetManager.validatorRewardVault()) == address(input.vault), "ASSETMGR-80");
+            require(address(assetManager.VALIDATOR_MANAGER()) == address(output.validatorManagerProxy), "ASSETMGR-90");
+            require(address(assetManager.validatorManager()) == address(output.validatorManagerProxy), "ASSETMGR-100");
+            require(assetManager.MIN_DELEGATION_PERIOD() == input.minDelegationPeriod, "ASSETMGR-110");
+            require(assetManager.minDelegationPeriod() == input.minDelegationPeriod, "ASSETMGR-120");
+            require(assetManager.BOND_AMOUNT() == input.bondAmount, "ASSETMGR-130");
+            require(assetManager.bondAmount() == input.bondAmount, "ASSETMGR-140");
+        } else {
+            assetManager = IAssetManager(output.assetManagerImpl);
+            uint256 slot = uint256(keccak256("unstructured.initializable.initialized")) - 1;
+            DeployUtils.assertInitialized(address(assetManager), slot, 0);
+            require(address(assetManager.ASSET_TOKEN()) == address(0), "ASSETMGR-10");
+            require(address(assetManager.assetToken()) == address(0), "ASSETMGR-20");
+            require(address(assetManager.KGH()) == address(0), "ASSETMGR-30");
+            require(address(assetManager.kgh()) == address(0), "ASSETMGR-40");
+            require(address(assetManager.SECURITY_COUNCIL()) == address(0), "ASSETMGR-50");
+            require(address(assetManager.securityCouncil()) == address(0), "ASSETMGR-60");
+            require(address(assetManager.VALIDATOR_REWARD_VAULT()) == address(0), "ASSETMGR-70");
+            require(address(assetManager.validatorRewardVault()) == address(0), "ASSETMGR-80");
+            require(address(assetManager.VALIDATOR_MANAGER()) == address(0), "ASSETMGR-90");
+            require(address(assetManager.validatorManager()) == address(0), "ASSETMGR-100");
+            require(assetManager.MIN_DELEGATION_PERIOD() == 0, "ASSETMGR-110");
+            require(assetManager.minDelegationPeriod() == 0, "ASSETMGR-120");
+            require(assetManager.BOND_AMOUNT() == 0, "ASSETMGR-130");
+            require(assetManager.bondAmount() == 0, "ASSETMGR-140");
+        }
+    }
+
+    function assertValidColosseum(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] Colosseum (isProxy: %s)", _isProxy);
+        IColosseum colosseum;
+        if (_isProxy) {
+            colosseum = IColosseum(output.colosseumProxy);
+            require(address(colosseum.L2_ORACLE()) == address(input.l2OutputOracle), "COLOSSEUM-10");
+            require(address(colosseum.l2Oracle()) == address(input.l2OutputOracle), "COLOSSEUM-20");
+            require(address(colosseum.ZK_PROOF_VERIFIER()) == address(output.zkProofVerifierProxy), "COLOSSEUM-30");
+            require(address(colosseum.zkProofVerifier()) == address(output.zkProofVerifierProxy), "COLOSSEUM-40");
+            require(colosseum.L2_ORACLE_SUBMISSION_INTERVAL() == input.submissionInterval, "COLOSSEUM-50");
+            require(colosseum.l2OracleSubmissionInterval() == input.submissionInterval, "COLOSSEUM-60");
+            require(colosseum.CREATION_PERIOD_SECONDS() == input.creationPeriodSeconds, "COLOSSEUM-70");
+            require(colosseum.creationPeriodSeconds() == input.creationPeriodSeconds, "COLOSSEUM-80");
+            require(colosseum.BISECTION_TIMEOUT() == input.bisectionTimeout, "COLOSSEUM-90");
+            require(colosseum.bisectionTimeout() == input.bisectionTimeout, "COLOSSEUM-100");
+            require(colosseum.PROVING_TIMEOUT() == input.provingTimeout, "COLOSSEUM-110");
+            require(colosseum.provingTimeout() == input.provingTimeout, "COLOSSEUM-120");
+            require(colosseum.segmentsLengths(0) == input.segmentsLengths[0], "COLOSSEUM-130");
+            require(address(colosseum.SECURITY_COUNCIL()) == address(output.securityCouncilProxy), "COLOSSEUM-140");
+            require(address(colosseum.securityCouncil()) == address(output.securityCouncilProxy), "COLOSSEUM-150");
+        } else {
+            colosseum = IColosseum(output.colosseumImpl);
+            DeployUtils.assertInitialized(address(colosseum), 0, 0);
+            require(address(colosseum.L2_ORACLE()) == address(0), "COLOSSEUM-10");
+            require(address(colosseum.l2Oracle()) == address(0), "COLOSSEUM-20");
+            require(address(colosseum.ZK_PROOF_VERIFIER()) == address(0), "COLOSSEUM-30");
+            require(address(colosseum.zkProofVerifier()) == address(0), "COLOSSEUM-40");
+            require(colosseum.L2_ORACLE_SUBMISSION_INTERVAL() == 0, "COLOSSEUM-50");
+            require(colosseum.l2OracleSubmissionInterval() == 0, "COLOSSEUM-60");
+            require(colosseum.CREATION_PERIOD_SECONDS() == 0, "COLOSSEUM-70");
+            require(colosseum.creationPeriodSeconds() == 0, "COLOSSEUM-80");
+            require(colosseum.BISECTION_TIMEOUT() == 0, "COLOSSEUM-90");
+            require(colosseum.bisectionTimeout() == 0, "COLOSSEUM-100");
+            require(colosseum.PROVING_TIMEOUT() == 0, "COLOSSEUM-110");
+            require(colosseum.provingTimeout() == 0, "COLOSSEUM-120");
+            require(colosseum.segmentsLengths(0) == 0, "COLOSSEUM-130");
+            require(address(colosseum.SECURITY_COUNCIL()) == address(0), "COLOSSEUM-140");
+            require(address(colosseum.securityCouncil()) == address(0), "COLOSSEUM-150");
+        }
+    }
+
+    function assertValidSecurityCouncil(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] SecurityCouncil (isProxy: %s)", _isProxy);
+        ISecurityCouncil securityCouncil;
+        if (_isProxy) {
+            securityCouncil = ISecurityCouncil(output.securityCouncilProxy);
+            require(securityCouncil.COLOSSEUM() == address(output.colosseumProxy), "SC-10");
+            require(securityCouncil.colosseum() == address(output.colosseumProxy), "SC-20");
+            require(address(securityCouncil.GOVERNOR()) == address(output.upgradeGovernorProxy), "SC-30");
+            require(address(securityCouncil.governor()) == address(output.upgradeGovernorProxy), "SC-40");
+        } else {
+            securityCouncil = ISecurityCouncil(output.securityCouncilImpl);
+            DeployUtils.assertInitialized(address(securityCouncil), 0, 0);
+            require(securityCouncil.COLOSSEUM() == address(0), "SC-10");
+            require(securityCouncil.colosseum() == address(0), "SC-20");
+            require(address(securityCouncil.GOVERNOR()) == address(0), "SC-30");
+            require(address(securityCouncil.governor()) == address(0), "SC-40");
+        }
+    }
+
+    function assertValidSecurityCouncilToken(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] SecurityCouncilToken (isProxy: %s)", _isProxy);
+        ISecurityCouncilToken securityCouncilToken;
+        if (_isProxy) {
+            securityCouncilToken = ISecurityCouncilToken(output.securityCouncilTokenProxy);
+            require(address(securityCouncilToken.owner()) == address(output.upgradeGovernorProxy), "SCT-10");
+        } else {
+            securityCouncilToken = ISecurityCouncilToken(output.securityCouncilTokenImpl);
+            DeployUtils.assertInitialized(address(securityCouncilToken), 0, 0);
+            require(address(securityCouncilToken.owner()) == address(0), "SCT-10");
+        }
+    }
+
+    function assertValidTimeLock(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] TimeLock (isProxy: %s)", _isProxy);
+        ITimeLock timelock;
+        if (_isProxy) {
+            timelock = ITimeLock(output.timeLockProxy);
+            require(timelock.getMinDelay() == input.timeLockMinDelaySeconds, "TL-10");
+        } else {
+            timelock = ITimeLock(output.timeLockImpl);
+            DeployUtils.assertInitialized(address(timelock), 0, 0);
+            require(timelock.getMinDelay() == 0, "TL-10");
+        }
+    }
+
+    function assertValidUpgradeGovernor(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] UpgradeGovernor (isProxy: %s)", _isProxy);
+        IUpgradeGovernor governor;
+        if (_isProxy) {
+            governor = IUpgradeGovernor(output.upgradeGovernorProxy);
+            require(address(governor.token()) == address(output.securityCouncilTokenProxy), "UG-10");
+            require(address(governor.timelock()) == address(output.timeLockProxy), "UG-20");
+            require(governor.votingDelay() == input.initialVotingDelay, "UG-30");
+            require(governor.votingPeriod() == input.initialVotingPeriod, "UG-40");
+            require(governor.proposalThreshold() == input.initialProposalThreshold, "UG-50");
+            require(governor.quorumNumerator() == input.votesQuorumFraction, "UG-60");
+        } else {
+            governor = IUpgradeGovernor(output.upgradeGovernorImpl);
+            DeployUtils.assertInitialized(address(governor), 0, 0);
+            require(address(governor.token()) == address(0), "UG-10");
+            require(address(governor.timelock()) == address(0), "UG-20");
+            require(governor.votingDelay() == 0, "UG-30");
+            require(governor.votingPeriod() == 0, "UG-40");
+            require(governor.proposalThreshold() == 0, "UG-50");
+            require(governor.quorumNumerator() == 0, "UG-60");
+        }
+    }
+
+    function assertValidValidatorManager(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] ValidatorManager (isProxy: %s)", _isProxy);
+        IValidatorManager validatorManager;
+        if (_isProxy) {
+            validatorManager = IValidatorManager(output.validatorManagerProxy);
+            require(address(validatorManager.L2_ORACLE()) == address(input.l2OutputOracle), "VM-10");
+            require(address(validatorManager.l2Oracle()) == address(input.l2OutputOracle), "VM-20");
+            require(address(validatorManager.ASSET_MANAGER()) == address(output.assetManagerProxy), "VM-30");
+            require(address(validatorManager.assetManager()) == address(output.assetManagerProxy), "VM-40");
+            require(validatorManager.TRUSTED_VALIDATOR() == address(input.trustedValidator), "VM-50");
+            require(validatorManager.trustedValidator() == address(input.trustedValidator), "VM-60");
+            require(validatorManager.COMMISSION_CHANGE_DELAY_SECONDS() == input.commissionChangeDelaySeconds, "VM-70");
+            require(validatorManager.commissionChangeDelaySeconds() == input.commissionChangeDelaySeconds, "VM-80");
+            require(validatorManager.ROUND_DURATION_SECONDS() == input.roundDurationSeconds, "VM-90");
+            require(validatorManager.roundDurationSeconds() == input.roundDurationSeconds, "VM-100");
+            require(validatorManager.SOFT_JAIL_PERIOD_SECONDS() == input.softJailPeriodSeconds, "VM-110");
+            require(validatorManager.softJailPeriodSeconds() == input.softJailPeriodSeconds, "VM-120");
+            require(validatorManager.HARD_JAIL_PERIOD_SECONDS() == input.hardJailPeriodSeconds, "VM-130");
+            require(validatorManager.hardJailPeriodSeconds() == input.hardJailPeriodSeconds, "VM-140");
+            require(validatorManager.JAIL_THRESHOLD() == input.jailThreshold, "VM-150");
+            require(validatorManager.jailThreshold() == input.jailThreshold, "VM-160");
+            require(validatorManager.MAX_OUTPUT_FINALIZATIONS() == input.maxFinalizations, "VM-170");
+            require(validatorManager.maxOutputFinalizations() == input.maxFinalizations, "VM-180");
+            require(validatorManager.BASE_REWARD() == input.baseReward, "VM-190");
+            require(validatorManager.baseReward() == input.baseReward, "VM-200");
+            require(validatorManager.MIN_REGISTER_AMOUNT() == input.minRegisterAmount, "VM-210");
+            require(validatorManager.minRegisterAmount() == input.minRegisterAmount, "VM-220");
+            require(validatorManager.MIN_ACTIVATE_AMOUNT() == input.minActivateAmount, "VM-230");
+            require(validatorManager.minActiveAmount() == input.minActivateAmount, "VM-240");
+        } else {
+            validatorManager = IValidatorManager(output.validatorManagerImpl);
+            uint256 slot = uint256(keccak256("unstructured.initializable.initialized")) - 1;
+            DeployUtils.assertInitialized(address(validatorManager), slot, 0);
+            require(address(validatorManager.L2_ORACLE()) == address(0), "VM-10");
+            require(address(validatorManager.l2Oracle()) == address(0), "VM-20");
+            require(address(validatorManager.ASSET_MANAGER()) == address(0), "VM-30");
+            require(address(validatorManager.assetManager()) == address(0), "VM-40");
+            require(validatorManager.TRUSTED_VALIDATOR() == address(0), "VM-50");
+            require(validatorManager.trustedValidator() == address(0), "VM-60");
+            require(validatorManager.COMMISSION_CHANGE_DELAY_SECONDS() == 0, "VM-70");
+            require(validatorManager.commissionChangeDelaySeconds() == 0, "VM-80");
+            require(validatorManager.ROUND_DURATION_SECONDS() == 0, "VM-90");
+            require(validatorManager.roundDurationSeconds() == 0, "VM-100");
+            require(validatorManager.SOFT_JAIL_PERIOD_SECONDS() == 0, "VM-110");
+            require(validatorManager.softJailPeriodSeconds() == 0, "VM-120");
+            require(validatorManager.HARD_JAIL_PERIOD_SECONDS() == 0, "VM-130");
+            require(validatorManager.hardJailPeriodSeconds() == 0, "VM-140");
+            require(validatorManager.JAIL_THRESHOLD() == 0, "VM-150");
+            require(validatorManager.jailThreshold() == 0, "VM-160");
+            require(validatorManager.MAX_OUTPUT_FINALIZATIONS() == 0, "VM-170");
+            require(validatorManager.maxOutputFinalizations() == 0, "VM-180");
+            require(validatorManager.BASE_REWARD() == 0, "VM-190");
+            require(validatorManager.baseReward() == 0, "VM-200");
+            require(validatorManager.MIN_REGISTER_AMOUNT() == 0, "VM-210");
+            require(validatorManager.minRegisterAmount() == 0, "VM-220");
+            require(validatorManager.MIN_ACTIVATE_AMOUNT() == 0, "VM-230");
+            require(validatorManager.minActiveAmount() == 0, "VM-240");
+        }
+    }
+
+    function assertValidZKProofVerifier(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output,
+        DeployConfig _cfg,
+        bool _isProxy
+    )
+        internal
+        view
+    {
+        console.log("[ASSERT] ZKProofVerifier (isProxy: %s)", _isProxy);
+        IZKProofVerifier zkProofVerifier;
+        if (_isProxy) {
+            zkProofVerifier = IZKProofVerifier(output.zkProofVerifierProxy);
+            require(address(zkProofVerifier.sp1Verifier()) == address(input.zkProofVerifierSP1Verifier), "ZKP-10");
+            require(zkProofVerifier.zkVmProgramVKey() == input.zkProofVerifierVKey, "ZKP-20");
+        } else {
+            zkProofVerifier = IZKProofVerifier(output.zkProofVerifierImpl);
+            require(address(zkProofVerifier.sp1Verifier()) == address(input.zkProofVerifierSP1Verifier), "ZKP-10");
+            require(zkProofVerifier.zkVmProgramVKey() == input.zkProofVerifierVKey, "ZKP-20");
+        }
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaConfigBuilder.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaConfigBuilder.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Scripts
+import { KromaDeployInput } from "scripts/deploy/kroma/KromaDeployTypes.sol";
+import { DeployConfig } from "scripts/deploy/DeployConfig.s.sol";
+import { Deploy } from "scripts/deploy/Deploy.s.sol";
+
+// Interfaces
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+
+/// @title KromaConfigBuilder
+/// @notice Builds a KromaDeployInput struct from an existing DeployConfig contract
+library KromaConfigBuilder {
+    /// @notice Builds a KromaDeployInput from DeployConfig
+    /// @param cfg The loaded DeployConfig instance
+    /// @return input The populated KromaDeployInput
+    function fromConfig(DeployConfig cfg) internal view returns (KromaDeployInput memory) {
+        return KromaDeployInput({
+            kgh: IERC721(cfg.assetManagerKgh()),
+            vault: cfg.assetManagerVault(),
+            minDelegationPeriod: cfg.assetManagerMinDelegationPeriod(),
+            bondAmount: cfg.assetManagerBondAmount(),
+            l2OutputOracle: IL2OutputOracle(address(0)),
+            submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
+            creationPeriodSeconds: cfg.colosseumCreationPeriodSeconds(),
+            bisectionTimeout: cfg.colosseumBisectionTimeout(),
+            provingTimeout: cfg.colosseumProvingTimeout(),
+            segmentsLengths: cfg.getColosseumSegmentsLengths(),
+            timeLockMinDelaySeconds: cfg.timeLockMinDelaySeconds(),
+            initialVotingDelay: cfg.governorVotingDelayBlocks(),
+            initialVotingPeriod: cfg.governorVotingPeriodBlocks(),
+            initialProposalThreshold: cfg.governorProposalThreshold(),
+            votesQuorumFraction: cfg.governorVotesQuorumFractionPercent(),
+            trustedValidator: cfg.validatorManagerTrustedValidator(),
+            minRegisterAmount: cfg.validatorManagerMinRegisterAmount(),
+            minActivateAmount: cfg.validatorManagerMinActivateAmount(),
+            commissionChangeDelaySeconds: cfg.validatorManagerCommissionChangeDelaySeconds(),
+            roundDurationSeconds: cfg.validatorManagerRoundDurationSeconds(),
+            softJailPeriodSeconds: cfg.validatorManagerSoftJailPeriodSeconds(),
+            hardJailPeriodSeconds: cfg.validatorManagerHardJailPeriodSeconds(),
+            jailThreshold: cfg.validatorManagerJailThreshold(),
+            maxFinalizations: cfg.validatorManagerMaxFinalizations(),
+            baseReward: cfg.validatorManagerBaseReward(),
+            zkProofVerifierSP1Verifier: cfg.zkProofVerifierSP1Verifier(),
+            zkProofVerifierVKey: cfg.zkProofVerifierVKey()
+        });
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaConfigBuilder.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaConfigBuilder.sol
@@ -9,7 +9,7 @@ import { Deploy } from "scripts/deploy/Deploy.s.sol";
 // Interfaces
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
 
 /// @title KromaConfigBuilder
 /// @notice Builds a KromaDeployInput struct from an existing DeployConfig contract
@@ -23,7 +23,7 @@ library KromaConfigBuilder {
             vault: cfg.assetManagerVault(),
             minDelegationPeriod: cfg.assetManagerMinDelegationPeriod(),
             bondAmount: cfg.assetManagerBondAmount(),
-            l2OutputOracle: IL2OutputOracle(address(0)),
+            l2OutputOracle: IKromaL2OutputOracle(address(0)),
             submissionInterval: cfg.l2OutputOracleSubmissionInterval(),
             creationPeriodSeconds: cfg.colosseumCreationPeriodSeconds(),
             bisectionTimeout: cfg.colosseumBisectionTimeout(),

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployTypes.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployTypes.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 // Interfaces
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
 import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
 import { IColosseum } from "interfaces/L1/IColosseum.sol";
 import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
@@ -21,7 +21,7 @@ struct KromaDeployInput {
     uint128 minDelegationPeriod;
     uint128 bondAmount;
     // Colosseum
-    IL2OutputOracle l2OutputOracle;
+    IKromaL2OutputOracle l2OutputOracle;
     uint256 submissionInterval;
     uint256 creationPeriodSeconds;
     uint256 bisectionTimeout;

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployTypes.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployTypes.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Interfaces
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
+import { IColosseum } from "interfaces/L1/IColosseum.sol";
+import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
+import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
+import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
+import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
+import { IKromaGovernanceToken } from "interfaces/governance/IKromaGovernanceToken.sol";
+
+struct KromaDeployInput {
+    // AssetManager
+    IERC721 kgh;
+    address vault;
+    uint128 minDelegationPeriod;
+    uint128 bondAmount;
+    // Colosseum
+    IL2OutputOracle l2OutputOracle;
+    uint256 submissionInterval;
+    uint256 creationPeriodSeconds;
+    uint256 bisectionTimeout;
+    uint256 provingTimeout;
+    uint256[] segmentsLengths;
+    // SecurityCouncil
+    uint256 timeLockMinDelaySeconds;
+    // UpgradeGovernor
+    uint256 initialVotingDelay;
+    uint256 initialVotingPeriod;
+    uint256 initialProposalThreshold;
+    uint256 votesQuorumFraction;
+    // ValidatorManager
+    address trustedValidator;
+    uint128 minRegisterAmount;
+    uint128 minActivateAmount;
+    uint128 commissionChangeDelaySeconds;
+    uint128 roundDurationSeconds;
+    uint128 softJailPeriodSeconds;
+    uint128 hardJailPeriodSeconds;
+    uint128 jailThreshold;
+    uint128 maxFinalizations;
+    uint128 baseReward;
+    // ZKProofVerifier
+    address zkProofVerifierSP1Verifier;
+    bytes32 zkProofVerifierVKey;
+}
+
+struct KromaDeployOutput {
+    // Proxy
+    IAssetManager assetManagerProxy;
+    IColosseum colosseumProxy;
+    ISecurityCouncil securityCouncilProxy;
+    ISecurityCouncilToken securityCouncilTokenProxy;
+    ITimeLock timeLockProxy;
+    IUpgradeGovernor upgradeGovernorProxy;
+    IValidatorManager validatorManagerProxy;
+    IZKProofVerifier zkProofVerifierProxy;
+    IKromaGovernanceToken kromaGovernanceTokenProxy;
+    // Impl
+    IAssetManager assetManagerImpl;
+    IColosseum colosseumImpl;
+    ISecurityCouncil securityCouncilImpl;
+    ISecurityCouncilToken securityCouncilTokenImpl;
+    ITimeLock timeLockImpl;
+    IUpgradeGovernor upgradeGovernorImpl;
+    IValidatorManager validatorManagerImpl;
+    IZKProofVerifier zkProofVerifierImpl;
+    IKromaGovernanceToken kromaGovernanceTokenImpl;
+}

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployer.sol
@@ -16,7 +16,6 @@ import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
 import { IProxy } from "interfaces/universal/IProxy.sol";
 import { ISP1Verifier } from "interfaces/vendor/sp1/ISP1Verifier.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
 import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
 import { IColosseum } from "interfaces/L1/IColosseum.sol";
 import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployer.sol
@@ -28,30 +28,19 @@ import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
 import { IKromaGovernanceToken } from "interfaces/governance/IKromaGovernanceToken.sol";
 
 /// @title KromaDeployer
-/// @notice Deploys and initializes all contracts related to the Kroma L1 system.
-///         This includes both implementation contracts and proxies.
-/// @dev Used as a library from top-level deploy scripts like `deploy.s.sol`.
+/// @notice Library for deploying and initializing all Kroma L1 contracts.
+/// @dev Called from top-level deployment script (e.g. Deploy.s.sol).
 library KromaDeployer {
-    /// @notice Deploys all Kroma L1 contracts as proxy patterns and sets initial logic/ownership.
-    /// @param deployProxy Function used to deploy EIP-1967 proxy instances.
-    /// @param deployImpl Function used to deploy logic (implementation) contracts.
-    /// @param proxyAdmin The ProxyAdmin contract managing upgrade rights.
-    /// @param input Struct containing deployment and initialization parameters.
-    /// @param vm Forge's cheatcode interface for broadcast control.
-    /// @return output Struct containing all deployed proxy contract addresses.
-    function deployAll(
-        function(string memory) returns (address) deployProxy,
+    /// @notice Deploys all implementation contracts.
+    function deployImpls(
         function(string memory, bytes memory) returns (address) deployImpl,
-        IProxyAdmin proxyAdmin,
-        KromaDeployInput memory input,
-        Vm vm
+        KromaDeployInput memory input
     )
         internal
         returns (KromaDeployOutput memory output)
     {
-        console.log("[Kroma Deploy] Deploying implementations...");
+        console.log("   > Deploying all implementation contracts");
 
-        // ========== Implementation Contracts ========== //
         output.assetManagerImpl = IAssetManager(deployImpl("AssetManager", abi.encode()));
         output.colosseumImpl = IColosseum(deployImpl("Colosseum", abi.encode()));
         output.securityCouncilImpl = ISecurityCouncil(deployImpl("SecurityCouncil", abi.encode()));
@@ -59,7 +48,6 @@ library KromaDeployer {
         output.timeLockImpl = ITimeLock(payable(deployImpl("TimeLock", abi.encode())));
         output.upgradeGovernorImpl = IUpgradeGovernor(payable(deployImpl("UpgradeGovernor", abi.encode())));
         output.validatorManagerImpl = IValidatorManager(deployImpl("ValidatorManager", abi.encode()));
-
         output.zkProofVerifierImpl = IZKProofVerifier(
             deployImpl(
                 "ZKProofVerifier",
@@ -72,7 +60,18 @@ library KromaDeployer {
             )
         );
 
-        console.log("[Kroma Deploy] Deploying proxies...");
+        return output;
+    }
+
+    /// @notice Deploys all proxy contracts.
+    function deployProxies(
+        function(string memory) returns (address) deployProxy,
+        KromaDeployOutput memory output
+    )
+        internal
+        returns (KromaDeployOutput memory)
+    {
+        console.log("   > [Proxy] Deploying proxy contracts");
 
         output.assetManagerProxy = IAssetManager(payable(deployProxy("AssetManagerProxy")));
         output.colosseumProxy = IColosseum(payable(deployProxy("ColosseumProxy")));
@@ -84,54 +83,63 @@ library KromaDeployer {
         output.zkProofVerifierProxy = IZKProofVerifier(payable(deployProxy("ZKProofVerifierProxy")));
         output.kromaGovernanceTokenProxy = IKromaGovernanceToken(payable(deployProxy("KromaGovernanceTokenProxy")));
 
-        console.log("[Kroma Deploy] Proxies deployed.");
+        console.log("    > All proxy contracts deployed");
+        return output;
+    }
 
-        // ========== Proxy Upgrade & Initialization ========== //
-        console.log("[Kroma Deploy] Upgrading and initializing proxies...");
+    /// @notice Upgrades and initializes all proxy contracts with their implementations.
+    function upgradeAndInitializeProxies(
+        IProxyAdmin proxyAdmin,
+        KromaDeployInput memory input,
+        function(string memory) view returns (address payable) mustGetAddress,
+        Vm vm
+    )
+        internal
+    {
+        console.log("   > [Upgrade] Initializing and upgrading proxies");
 
-        vm.startBroadcast();
+        vm.startBroadcast(msg.sender);
 
         proxyAdmin.upgradeAndCall(
-            payable(address(output.assetManagerProxy)),
-            address(output.assetManagerImpl),
-            KromaInitializers.encodeAssetManagerInitializer(input, output)
+            payable(mustGetAddress("AssetManagerProxy")),
+            mustGetAddress("AssetManager"),
+            KromaInitializers.encodeAssetManagerInitializer(input, mustGetAddress)
         );
         proxyAdmin.upgradeAndCall(
-            payable(address(output.colosseumProxy)),
-            address(output.colosseumImpl),
-            KromaInitializers.encodeColosseumInitializer(input, output)
+            payable(mustGetAddress("ColosseumProxy")),
+            mustGetAddress("Colosseum"),
+            KromaInitializers.encodeColosseumInitializer(input, mustGetAddress)
         );
         proxyAdmin.upgradeAndCall(
-            payable(address(output.securityCouncilProxy)),
-            address(output.securityCouncilImpl),
-            KromaInitializers.encodeSecurityCouncilInitializer(output)
+            payable(mustGetAddress("SecurityCouncilProxy")),
+            mustGetAddress("SecurityCouncil"),
+            KromaInitializers.encodeSecurityCouncilInitializer(mustGetAddress)
         );
         proxyAdmin.upgradeAndCall(
-            payable(address(output.securityCouncilTokenProxy)),
-            address(output.securityCouncilTokenImpl),
-            KromaInitializers.encodeSecurityCouncilTokenInitializer(output)
+            payable(mustGetAddress("SecurityCouncilTokenProxy")),
+            mustGetAddress("SecurityCouncilToken"),
+            KromaInitializers.encodeSecurityCouncilTokenInitializer(mustGetAddress)
         );
         proxyAdmin.upgradeAndCall(
-            payable(address(output.timeLockProxy)),
-            address(output.timeLockImpl),
-            KromaInitializers.encodeTimeLockInitializer(input, output)
+            payable(mustGetAddress("TimeLockProxy")),
+            mustGetAddress("TimeLock"),
+            KromaInitializers.encodeTimeLockInitializer(input, mustGetAddress)
         );
         proxyAdmin.upgradeAndCall(
-            payable(address(output.upgradeGovernorProxy)),
-            address(output.upgradeGovernorImpl),
-            KromaInitializers.encodeUpgradeGovernorInitializer(input, output)
+            payable(mustGetAddress("UpgradeGovernorProxy")),
+            mustGetAddress("UpgradeGovernor"),
+            KromaInitializers.encodeUpgradeGovernorInitializer(input, mustGetAddress)
         );
         proxyAdmin.upgradeAndCall(
-            payable(address(output.validatorManagerProxy)),
-            address(output.validatorManagerImpl),
-            KromaInitializers.encodeValidatorManagerInitializer(input, output)
+            payable(mustGetAddress("ValidatorManagerProxy")),
+            mustGetAddress("ValidatorManager"),
+            KromaInitializers.encodeValidatorManagerInitializer(input, mustGetAddress)
         );
-        proxyAdmin.upgrade(payable(address(output.zkProofVerifierProxy)), address(output.zkProofVerifierImpl));
+
+        proxyAdmin.upgrade(payable(mustGetAddress("ZKProofVerifierProxy")), mustGetAddress("ZKProofVerifier"));
 
         vm.stopBroadcast();
 
-        console.log("[Kroma Deploy] All contracts deployed, initialized, and verified successfully.");
-
-        return output;
+        console.log("    > All proxies upgraded and initialized");
     }
 }

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployer.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaDeployer.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Scripts
+import { Vm } from "forge-std/Vm.sol";
+import { console2 as console } from "forge-std/console2.sol";
+
+// Libraries
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+import { KromaInitializers } from "scripts/deploy/kroma/KromaInitializers.sol";
+import { KromaDeployInput, KromaDeployOutput } from "scripts/deploy/kroma/KromaDeployTypes.sol";
+import { KromaChainAssertions } from "scripts/deploy/kroma/KromaChainAssertions.sol";
+
+// Interfaces
+import { IProxyAdmin } from "interfaces/universal/IProxyAdmin.sol";
+import { IProxy } from "interfaces/universal/IProxy.sol";
+import { ISP1Verifier } from "interfaces/vendor/sp1/ISP1Verifier.sol";
+import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
+import { IColosseum } from "interfaces/L1/IColosseum.sol";
+import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
+import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
+import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
+import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
+import { IKromaGovernanceToken } from "interfaces/governance/IKromaGovernanceToken.sol";
+
+/// @title KromaDeployer
+/// @notice Deploys and initializes all contracts related to the Kroma L1 system.
+///         This includes both implementation contracts and proxies.
+/// @dev Used as a library from top-level deploy scripts like `deploy.s.sol`.
+library KromaDeployer {
+    /// @notice Deploys all Kroma L1 contracts as proxy patterns and sets initial logic/ownership.
+    /// @param deployProxy Function used to deploy EIP-1967 proxy instances.
+    /// @param deployImpl Function used to deploy logic (implementation) contracts.
+    /// @param proxyAdmin The ProxyAdmin contract managing upgrade rights.
+    /// @param input Struct containing deployment and initialization parameters.
+    /// @param vm Forge's cheatcode interface for broadcast control.
+    /// @return output Struct containing all deployed proxy contract addresses.
+    function deployAll(
+        function(string memory) returns (address) deployProxy,
+        function(string memory, bytes memory) returns (address) deployImpl,
+        IProxyAdmin proxyAdmin,
+        KromaDeployInput memory input,
+        Vm vm
+    )
+        internal
+        returns (KromaDeployOutput memory output)
+    {
+        console.log("[Kroma Deploy] Deploying implementations...");
+
+        // ========== Implementation Contracts ========== //
+        output.assetManagerImpl = IAssetManager(deployImpl("AssetManager", abi.encode()));
+        output.colosseumImpl = IColosseum(deployImpl("Colosseum", abi.encode()));
+        output.securityCouncilImpl = ISecurityCouncil(deployImpl("SecurityCouncil", abi.encode()));
+        output.securityCouncilTokenImpl = ISecurityCouncilToken(deployImpl("SecurityCouncilToken", abi.encode()));
+        output.timeLockImpl = ITimeLock(payable(deployImpl("TimeLock", abi.encode())));
+        output.upgradeGovernorImpl = IUpgradeGovernor(payable(deployImpl("UpgradeGovernor", abi.encode())));
+        output.validatorManagerImpl = IValidatorManager(deployImpl("ValidatorManager", abi.encode()));
+
+        output.zkProofVerifierImpl = IZKProofVerifier(
+            deployImpl(
+                "ZKProofVerifier",
+                DeployUtils.encodeConstructor(
+                    abi.encodeCall(
+                        IZKProofVerifier.__constructor__,
+                        (ISP1Verifier(input.zkProofVerifierSP1Verifier), input.zkProofVerifierVKey)
+                    )
+                )
+            )
+        );
+
+        console.log("[Kroma Deploy] Deploying proxies...");
+
+        output.assetManagerProxy = IAssetManager(payable(deployProxy("AssetManagerProxy")));
+        output.colosseumProxy = IColosseum(payable(deployProxy("ColosseumProxy")));
+        output.securityCouncilProxy = ISecurityCouncil(payable(deployProxy("SecurityCouncilProxy")));
+        output.securityCouncilTokenProxy = ISecurityCouncilToken(payable(deployProxy("SecurityCouncilTokenProxy")));
+        output.timeLockProxy = ITimeLock(payable(deployProxy("TimeLockProxy")));
+        output.upgradeGovernorProxy = IUpgradeGovernor(payable(deployProxy("UpgradeGovernorProxy")));
+        output.validatorManagerProxy = IValidatorManager(payable(deployProxy("ValidatorManagerProxy")));
+        output.zkProofVerifierProxy = IZKProofVerifier(payable(deployProxy("ZKProofVerifierProxy")));
+        output.kromaGovernanceTokenProxy = IKromaGovernanceToken(payable(deployProxy("KromaGovernanceTokenProxy")));
+
+        console.log("[Kroma Deploy] Proxies deployed.");
+
+        // ========== Proxy Upgrade & Initialization ========== //
+        console.log("[Kroma Deploy] Upgrading and initializing proxies...");
+
+        vm.startBroadcast();
+
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.assetManagerProxy)),
+            address(output.assetManagerImpl),
+            KromaInitializers.encodeAssetManagerInitializer(input, output)
+        );
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.colosseumProxy)),
+            address(output.colosseumImpl),
+            KromaInitializers.encodeColosseumInitializer(input, output)
+        );
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.securityCouncilProxy)),
+            address(output.securityCouncilImpl),
+            KromaInitializers.encodeSecurityCouncilInitializer(output)
+        );
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.securityCouncilTokenProxy)),
+            address(output.securityCouncilTokenImpl),
+            KromaInitializers.encodeSecurityCouncilTokenInitializer(output)
+        );
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.timeLockProxy)),
+            address(output.timeLockImpl),
+            KromaInitializers.encodeTimeLockInitializer(input, output)
+        );
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.upgradeGovernorProxy)),
+            address(output.upgradeGovernorImpl),
+            KromaInitializers.encodeUpgradeGovernorInitializer(input, output)
+        );
+        proxyAdmin.upgradeAndCall(
+            payable(address(output.validatorManagerProxy)),
+            address(output.validatorManagerImpl),
+            KromaInitializers.encodeValidatorManagerInitializer(input, output)
+        );
+        proxyAdmin.upgrade(payable(address(output.zkProofVerifierProxy)), address(output.zkProofVerifierImpl));
+
+        vm.stopBroadcast();
+
+        console.log("[Kroma Deploy] All contracts deployed, initialized, and verified successfully.");
+
+        return output;
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaInitializers.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaInitializers.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// Libraries
+import { KromaDeployInput, KromaDeployOutput } from "scripts/deploy/kroma/KromaDeployTypes.sol";
+
+// Interfaces
+import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
+import { IColosseum } from "interfaces/L1/IColosseum.sol";
+import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
+import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
+import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
+import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
+import { IKromaGovernanceToken } from "interfaces/governance/IKromaGovernanceToken.sol";
+
+// Contracts
+import { SecurityCouncil } from "src/L1/SecurityCouncil.sol";
+
+/// @title KromaInitializers
+/// @notice Provides helper methods for encoding initializer calldata for Kroma-specific contracts.
+library KromaInitializers {
+    /// @notice Encodes initializer data for the AssetManager contract.
+    function encodeAssetManagerInitializer(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IAssetManager.initialize.selector,
+            output.kromaGovernanceTokenProxy,
+            input.kgh,
+            output.securityCouncilProxy,
+            input.vault,
+            output.validatorManagerProxy,
+            input.minDelegationPeriod,
+            input.bondAmount
+        );
+    }
+
+    /// @notice Encodes initializer data for the Colosseum contract.
+    function encodeColosseumInitializer(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IColosseum.initialize.selector,
+            input.l2OutputOracle,
+            output.zkProofVerifierProxy,
+            output.securityCouncilProxy,
+            input.submissionInterval,
+            input.creationPeriodSeconds,
+            input.bisectionTimeout,
+            input.provingTimeout,
+            input.segmentsLengths
+        );
+    }
+
+    /// @notice Encodes initializer data for the SecurityCouncil contract.
+    function encodeSecurityCouncilInitializer(KromaDeployOutput memory output) internal pure returns (bytes memory) {
+        return abi.encodeWithSelector(
+            SecurityCouncil.initialize.selector, output.colosseumProxy, output.upgradeGovernorProxy
+        );
+    }
+
+    /// @notice Encodes initializer data for the SecurityCouncilToken contract.
+    function encodeSecurityCouncilTokenInitializer(KromaDeployOutput memory output)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(ISecurityCouncilToken.initialize.selector, output.upgradeGovernorProxy);
+    }
+
+    /// @notice Encodes initializer data for the TimeLock contract.
+    function encodeTimeLockInitializer(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        address[] memory proposers = new address[](1);
+        address[] memory executors = new address[](1);
+        proposers[0] = address(output.upgradeGovernorProxy);
+        executors[0] = address(output.upgradeGovernorProxy);
+
+        return abi.encodeWithSelector(
+            ITimeLock.initialize.selector,
+            input.timeLockMinDelaySeconds,
+            proposers,
+            executors,
+            address(output.upgradeGovernorProxy)
+        );
+    }
+
+    /// @notice Encodes initializer data for the UpgradeGovernor contract.
+    function encodeUpgradeGovernorInitializer(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodeWithSelector(
+            IUpgradeGovernor.initialize.selector,
+            output.securityCouncilTokenProxy,
+            output.timeLockProxy,
+            input.initialVotingDelay,
+            input.initialVotingPeriod,
+            input.initialProposalThreshold,
+            input.votesQuorumFraction
+        );
+    }
+
+    /// @notice Encodes initializer data for the ValidatorManager contract.
+    function encodeValidatorManagerInitializer(
+        KromaDeployInput memory input,
+        KromaDeployOutput memory output
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        IValidatorManager.InitializationParams memory params = IValidatorManager.InitializationParams({
+            _l2Oracle: input.l2OutputOracle,
+            _assetManager: IAssetManager(output.assetManagerProxy),
+            _trustedValidator: input.trustedValidator,
+            _commissionChangeDelaySeconds: input.commissionChangeDelaySeconds,
+            _roundDurationSeconds: input.roundDurationSeconds,
+            _softJailPeriodSeconds: input.softJailPeriodSeconds,
+            _hardJailPeriodSeconds: input.hardJailPeriodSeconds,
+            _jailThreshold: input.jailThreshold,
+            _maxOutputFinalizations: input.maxFinalizations,
+            _baseReward: input.baseReward,
+            _minRegisterAmount: input.minRegisterAmount,
+            _minActivateAmount: input.minActivateAmount
+        });
+
+        return abi.encodeWithSelector(IValidatorManager.initialize.selector, params);
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/kroma/KromaInitializers.sol
+++ b/packages/contracts-bedrock/scripts/deploy/kroma/KromaInitializers.sol
@@ -20,23 +20,24 @@ import { SecurityCouncil } from "src/L1/SecurityCouncil.sol";
 
 /// @title KromaInitializers
 /// @notice Provides helper methods for encoding initializer calldata for Kroma-specific contracts.
+/// @dev Used by KromaDeployer during the upgradeAndCall process for each proxy contract.
 library KromaInitializers {
     /// @notice Encodes initializer data for the AssetManager contract.
     function encodeAssetManagerInitializer(
         KromaDeployInput memory input,
-        KromaDeployOutput memory output
+        function(string memory) view returns (address payable) mustGetAddress
     )
         internal
-        pure
+        view
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
             IAssetManager.initialize.selector,
-            output.kromaGovernanceTokenProxy,
+            mustGetAddress("KromaGovernanceTokenProxy"),
             input.kgh,
-            output.securityCouncilProxy,
+            mustGetAddress("SecurityCouncilProxy"),
             input.vault,
-            output.validatorManagerProxy,
+            mustGetAddress("ValidatorManagerProxy"),
             input.minDelegationPeriod,
             input.bondAmount
         );
@@ -45,17 +46,17 @@ library KromaInitializers {
     /// @notice Encodes initializer data for the Colosseum contract.
     function encodeColosseumInitializer(
         KromaDeployInput memory input,
-        KromaDeployOutput memory output
+        function(string memory) view returns (address payable) mustGetAddress
     )
         internal
-        pure
+        view
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
             IColosseum.initialize.selector,
             input.l2OutputOracle,
-            output.zkProofVerifierProxy,
-            output.securityCouncilProxy,
+            mustGetAddress("ZKProofVerifierProxy"),
+            mustGetAddress("SecurityCouncilProxy"),
             input.submissionInterval,
             input.creationPeriodSeconds,
             input.bisectionTimeout,
@@ -65,57 +66,62 @@ library KromaInitializers {
     }
 
     /// @notice Encodes initializer data for the SecurityCouncil contract.
-    function encodeSecurityCouncilInitializer(KromaDeployOutput memory output) internal pure returns (bytes memory) {
+    function encodeSecurityCouncilInitializer(function(string memory) view returns (address payable) mustGetAddress)
+        internal
+        view
+        returns (bytes memory)
+    {
         return abi.encodeWithSelector(
-            SecurityCouncil.initialize.selector, output.colosseumProxy, output.upgradeGovernorProxy
+            SecurityCouncil.initialize.selector,
+            mustGetAddress("ColosseumProxy"),
+            mustGetAddress("UpgradeGovernorProxy")
         );
     }
 
     /// @notice Encodes initializer data for the SecurityCouncilToken contract.
-    function encodeSecurityCouncilTokenInitializer(KromaDeployOutput memory output)
+    function encodeSecurityCouncilTokenInitializer(
+        function(string memory) view returns (address payable) mustGetAddress
+    )
         internal
-        pure
+        view
         returns (bytes memory)
     {
-        return abi.encodeWithSelector(ISecurityCouncilToken.initialize.selector, output.upgradeGovernorProxy);
+        return abi.encodeWithSelector(ISecurityCouncilToken.initialize.selector, mustGetAddress("UpgradeGovernorProxy"));
     }
 
     /// @notice Encodes initializer data for the TimeLock contract.
     function encodeTimeLockInitializer(
         KromaDeployInput memory input,
-        KromaDeployOutput memory output
+        function(string memory) view returns (address payable) mustGetAddress
     )
         internal
-        pure
+        view
         returns (bytes memory)
     {
         address[] memory proposers = new address[](1);
         address[] memory executors = new address[](1);
-        proposers[0] = address(output.upgradeGovernorProxy);
-        executors[0] = address(output.upgradeGovernorProxy);
+        address upgradeGovernorProxy = mustGetAddress("UpgradeGovernorProxy");
+        proposers[0] = upgradeGovernorProxy;
+        executors[0] = upgradeGovernorProxy;
 
         return abi.encodeWithSelector(
-            ITimeLock.initialize.selector,
-            input.timeLockMinDelaySeconds,
-            proposers,
-            executors,
-            address(output.upgradeGovernorProxy)
+            ITimeLock.initialize.selector, input.timeLockMinDelaySeconds, proposers, executors, upgradeGovernorProxy
         );
     }
 
     /// @notice Encodes initializer data for the UpgradeGovernor contract.
     function encodeUpgradeGovernorInitializer(
         KromaDeployInput memory input,
-        KromaDeployOutput memory output
+        function(string memory) view returns (address payable) mustGetAddress
     )
         internal
-        pure
+        view
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
             IUpgradeGovernor.initialize.selector,
-            output.securityCouncilTokenProxy,
-            output.timeLockProxy,
+            mustGetAddress("SecurityCouncilTokenProxy"),
+            mustGetAddress("TimeLockProxy"),
             input.initialVotingDelay,
             input.initialVotingPeriod,
             input.initialProposalThreshold,
@@ -126,15 +132,15 @@ library KromaInitializers {
     /// @notice Encodes initializer data for the ValidatorManager contract.
     function encodeValidatorManagerInitializer(
         KromaDeployInput memory input,
-        KromaDeployOutput memory output
+        function(string memory) view returns (address payable) mustGetAddress
     )
         internal
-        pure
+        view
         returns (bytes memory)
     {
         IValidatorManager.InitializationParams memory params = IValidatorManager.InitializationParams({
             _l2Oracle: input.l2OutputOracle,
-            _assetManager: IAssetManager(output.assetManagerProxy),
+            _assetManager: IAssetManager(mustGetAddress("AssetManagerProxy")),
             _trustedValidator: input.trustedValidator,
             _commissionChangeDelaySeconds: input.commissionChangeDelaySeconds,
             _roundDurationSeconds: input.roundDurationSeconds,

--- a/packages/contracts-bedrock/scripts/libraries/Types.sol
+++ b/packages/contracts-bedrock/scripts/libraries/Types.sol
@@ -19,15 +19,5 @@ library Types {
         address ProtocolVersions;
         address SuperchainConfig;
         address OPContractsManager;
-        // [Kroma: START]
-        address AssetManager;
-        address Colosseum;
-        address SecurityCouncil;
-        address SecurityCouncilToken;
-        address TimeLock;
-        address UpgradeGovernor;
-        address ValidatorManager;
-        address ZkProofVerifier;
     }
-    // [Kroma: END]
 }

--- a/packages/contracts-bedrock/src/L1/AssetManager.sol
+++ b/packages/contracts-bedrock/src/L1/AssetManager.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.15;
 
 // Contracts
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { UnstructuredInitializable  } from "src/universal/UnstructuredInitializable.sol";
+import { UnstructuredInitializable } from "src/universal/UnstructuredInitializable.sol";
 
 // Libraries
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/packages/contracts-bedrock/src/L1/Colosseum.sol
+++ b/packages/contracts-bedrock/src/L1/Colosseum.sol
@@ -9,7 +9,7 @@ import { KromaTypes } from "src/libraries/KromaTypes.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
 import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
 import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
 
@@ -60,7 +60,7 @@ contract Colosseum is Initializable, ISemver {
     mapping(uint256 => KromaTypes.CheckpointOutput) public deletedOutputs;
 
     /// @notice Address of the L2OutputOracle.
-    IL2OutputOracle public l2Oracle;
+    IKromaL2OutputOracle public l2Oracle;
 
     /// @notice Address of the ZKProofVerifier.
     IZKProofVerifier public zkProofVerifier;
@@ -211,7 +211,7 @@ contract Colosseum is Initializable, ISemver {
     /// @param _provingTimeout        Timeout seconds for the proving.
     /// @param _segmentsLengths       Lengths of segments.
     function initialize(
-        IL2OutputOracle _l2Oracle,
+        IKromaL2OutputOracle _l2Oracle,
         IZKProofVerifier _zkProofVerifier,
         ISecurityCouncil _securityCouncil,
         uint256 _submissionInterval,
@@ -223,7 +223,7 @@ contract Colosseum is Initializable, ISemver {
         public
         reinitializer(2)
     {
-        l2Oracle = IL2OutputOracle(_l2Oracle);
+        l2Oracle = IKromaL2OutputOracle(_l2Oracle);
         zkProofVerifier = IZKProofVerifier(_zkProofVerifier);
         securityCouncil = ISecurityCouncil(_securityCouncil);
         l2OracleSubmissionInterval = _submissionInterval;
@@ -252,7 +252,7 @@ contract Colosseum is Initializable, ISemver {
     ///         Public getter is legacy and will be removed in the future. Use `l2Oracle` instead.
     /// @return Address of the l2OutputOracle.
     /// @custom:legacy
-    function L2_ORACLE() external view returns (IL2OutputOracle) {
+    function L2_ORACLE() external view returns (IKromaL2OutputOracle) {
         return l2Oracle;
     }
 

--- a/packages/contracts-bedrock/src/L1/KromaL2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/KromaL2OutputOracle.sol
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+// Contracts
+import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+// Libraries
+import { Constants } from "src/libraries/Constants.sol";
+import { KromaConstants } from "src/libraries/KromaConstants.sol";
+import { KromaTypes } from "src/libraries/KromaTypes.sol";
+
+// Interfaces
+import { ISemver } from "interfaces/universal/ISemver.sol";
+import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
+
+/// @custom:proxied
+/// @title KromaL2OutputOracle
+/// @notice The KromaL2OutputOracle contains an array of L2 state outputs, where each output is a
+///         commitment to the state of the L2 chain. Other contracts like the OptimismPortal use
+///         these outputs to verify information about the state of L2.
+contract KromaL2OutputOracle is Initializable, ISemver {
+    /// @notice The number of the first L2 block recorded in this contract.
+    uint256 public startingBlockNumber;
+
+    /// @notice The timestamp of the first L2 block recorded in this contract.
+    uint256 public startingTimestamp;
+
+    /// @notice Array of L2 checkpoint outputs.
+    KromaTypes.CheckpointOutput[] internal l2Outputs;
+
+    /// @notice The output index of the next finalization target output.
+    uint256 public nextFinalizeOutputIndex;
+
+    /// @notice The address of the validator manager contract. Can be updated via upgrade.
+    IValidatorManager public validatorManager;
+
+    /// @notice The address of the colosseum contract. Can be updated via upgrade.
+    address public colosseum;
+
+    /// @notice The interval in L2 blocks at which checkpoints must be submitted. Although this is
+    ///         immutable, it can be modified by upgrading the implementation contract.
+    ///         Note that nodes that fetch and use this value need to restart when it is modified.
+    uint256 public submissionInterval;
+
+    /// @notice The time between L2 blocks in seconds. Once set, this value MUST NOT be modified.
+    uint256 public l2BlockTime;
+
+    /// @notice Minimum time (in seconds) that must elapse before a withdrawal can be finalized.
+    uint256 public finalizationPeriodSeconds;
+
+    /// @notice Emitted when an output is submitted.
+    /// @param outputRoot    The output root.
+    /// @param l2OutputIndex The index of the output in the l2Outputs array.
+    /// @param l2BlockNumber The L2 block number of the output root.
+    /// @param l1Timestamp   The L1 timestamp when submitted.
+    event OutputSubmitted(
+        bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
+    );
+
+    /// @notice Emitted when an output is replaced.
+    /// @param outputIndex   Replaced L2 output index.
+    /// @param newSubmitter  Output submitter after replacement.
+    /// @param newOutputRoot L2 output root after replacement.
+    event OutputReplaced(uint256 indexed outputIndex, address indexed newSubmitter, bytes32 newOutputRoot);
+
+    /// @notice Semantic version.
+    /// @custom:semver 1.2.0
+    string public constant version = "1.2.0";
+
+    /// @notice Constructs the L2OutputOracle contract. Initializes variables to the same values as
+    ///         in the getting-started config.
+    constructor() {
+        initialize({
+            _validatorManager: IValidatorManager(address(0)),
+            _colosseum: address(0),
+            _submissionInterval: 1,
+            _l2BlockTime: 1,
+            _startingBlockNumber: 0,
+            _startingTimestamp: 0,
+            _finalizationPeriodSeconds: 0
+        });
+    }
+
+    /// @notice Initializer
+    /// @param _validatorManager          The address of the ValidatorManager contract.
+    /// @param _colosseum                 The address of the Colosseum contract.
+    /// @param _submissionInterval        Interval in blocks at which checkpoints must be submitted.
+    /// @param _l2BlockTime               The time per L2 block, in seconds.
+    /// @param _startingBlockNumber       The number of the first L2 block.
+    /// @param _startingTimestamp         The timestamp of the first L2 block.
+    /// @param _finalizationPeriodSeconds Output finalization time in seconds.
+    function initialize(
+        IValidatorManager _validatorManager,
+        address _colosseum,
+        uint256 _submissionInterval,
+        uint256 _l2BlockTime,
+        uint256 _startingBlockNumber,
+        uint256 _startingTimestamp,
+        uint256 _finalizationPeriodSeconds
+    )
+        public
+        reinitializer(2)
+    {
+        require(_l2BlockTime > 0, "L2OutputOracle: L2 block time must be greater than 0");
+        require(_submissionInterval > 0, "L2OutputOracle: submission interval must be greater than 0");
+        require(
+            _startingTimestamp <= block.timestamp,
+            "L2OutputOracle: starting L2 timestamp must be less than current time"
+        );
+        validatorManager = IValidatorManager(_validatorManager);
+        colosseum = _colosseum;
+        submissionInterval = _submissionInterval;
+        l2BlockTime = _l2BlockTime;
+        startingBlockNumber = _startingBlockNumber;
+        startingTimestamp = _startingTimestamp;
+        finalizationPeriodSeconds = _finalizationPeriodSeconds;
+    }
+
+    /// @notice Getter for the validatorManager address.
+    ///         Public getter is legacy and will be removed in the future. Use `validatorManager` instead.
+    /// @return Address of the validatorManager.
+    /// @custom:legacy
+    function VALIDATOR_MANAGER() external view returns (IValidatorManager) {
+        return validatorManager;
+    }
+
+    /// @notice Getter for the colosseum address.
+    ///         Public getter is legacy and will be removed in the future. Use `colosseum` instead.
+    /// @return Address of the colosseum.
+    /// @custom:legacy
+    function COLOSSEUM() external view returns (address) {
+        return colosseum;
+    }
+
+    /// @notice Getter for the submissionInterval.
+    ///         Public getter is legacy and will be removed in the future. Use `submissionInterval` instead.
+    /// @return Submission interval.
+    /// @custom:legacy
+    function SUBMISSION_INTERVAL() external view returns (uint256) {
+        return submissionInterval;
+    }
+
+    /// @notice Getter for the l2BlockTime.
+    ///         Public getter is legacy and will be removed in the future. Use `l2BlockTime` instead.
+    /// @return L2 block time.
+    /// @custom:legacy
+    function L2_BLOCK_TIME() external view returns (uint256) {
+        return l2BlockTime;
+    }
+
+    /// @notice Getter for the finalizationPeriodSeconds.
+    ///         Public getter is legacy and will be removed in the future. Use `finalizationPeriodSeconds` instead.
+    /// @return Finalization period in seconds.
+    /// @custom:legacy
+    function FINALIZATION_PERIOD_SECONDS() external view returns (uint256) {
+        return finalizationPeriodSeconds;
+    }
+
+    /// @notice Replaces the output that corresponds to the given output index.
+    ///         Only the Colosseum contract can replace an output.
+    /// @param _l2OutputIndex Index of the L2 output to be replaced.
+    /// @param _newOutputRoot The L2 output root to replace the existing one.
+    /// @param _submitter     Address of the L2 output submitter.
+    function replaceL2Output(uint256 _l2OutputIndex, bytes32 _newOutputRoot, address _submitter) external {
+        require(msg.sender == colosseum, "L2OutputOracle: only the colosseum contract can replace an output");
+
+        require(_submitter != address(0), "L2OutputOracle: submitter address cannot be zero");
+
+        // Make sure we're not *increasing* the length of the array.
+        require(
+            _l2OutputIndex < l2Outputs.length, "L2OutputOracle: cannot replace an output after the latest output index"
+        );
+
+        KromaTypes.CheckpointOutput storage output = l2Outputs[_l2OutputIndex];
+        // Do not allow replacing any outputs that have already been finalized.
+        require(
+            block.timestamp - output.timestamp < finalizationPeriodSeconds,
+            "L2OutputOracle: cannot replace an output that has already been finalized"
+        );
+
+        output.outputRoot = _newOutputRoot;
+        output.submitter = _submitter;
+
+        emit OutputReplaced(_l2OutputIndex, _submitter, _newOutputRoot);
+    }
+
+    /// @notice Accepts an outputRoot and the block number of the corresponding L2 block.
+    ///         The block number must be equal to the current value returned by `nextBlockNumber()`
+    ///         in order to be accepted. This function may only be called by the validator.
+    /// @param _outputRoot    The L2 output of the checkpoint block.
+    /// @param _l2BlockNumber The L2 block number that resulted in _outputRoot.
+    /// @param _l1BlockHash   A block hash which must be included in the current chain.
+    /// @param _l1BlockNumber The block number with the specified block hash.
+    function submitL2Output(
+        bytes32 _outputRoot,
+        uint256 _l2BlockNumber,
+        bytes32 _l1BlockHash,
+        uint256 _l1BlockNumber
+    )
+        external
+        payable
+    {
+        validatorManager.checkSubmissionEligibility(msg.sender);
+
+        require(
+            _l2BlockNumber == nextBlockNumber(),
+            "L2OutputOracle: block number must be equal to next expected block number"
+        );
+
+        require(nextOutputMinL2Timestamp() <= block.timestamp, "L2OutputOracle: cannot submit L2 output in the future");
+
+        require(_outputRoot != bytes32(0), "L2OutputOracle: L2 checkpoint output cannot be the zero hash");
+
+        if (_l1BlockHash != bytes32(0) && blockhash(_l1BlockNumber) != bytes32(0)) {
+            // This check allows the validator to submit an output based on a given L1 block,
+            // without fear that it will be reorged out.
+            // It will be skipped if the blockheight provided is more than 256 blocks behind the
+            // chain tip (as the hash will return as zero).
+            require(
+                blockhash(_l1BlockNumber) == _l1BlockHash,
+                "L2OutputOracle: block hash does not match the hash at the expected height"
+            );
+        }
+
+        l2Outputs.push(
+            KromaTypes.CheckpointOutput({
+                submitter: msg.sender,
+                outputRoot: _outputRoot,
+                timestamp: uint128(block.timestamp),
+                l2BlockNumber: uint128(_l2BlockNumber)
+            })
+        );
+
+        uint256 outputIndex = nextOutputIndex();
+
+        emit OutputSubmitted(_outputRoot, outputIndex, _l2BlockNumber, block.timestamp);
+
+        validatorManager.afterSubmitL2Output(outputIndex);
+    }
+
+    /// @notice Updates the next output index to be finalized.
+    /// @param _outputIndex Index of the next output to be finalized.
+    function setNextFinalizeOutputIndex(uint256 _outputIndex) external {
+        require(
+            msg.sender == address(validatorManager),
+            "L2OutputOracle: only the validator manager contract can set next finalize output index"
+        );
+
+        nextFinalizeOutputIndex = _outputIndex;
+    }
+
+    /// @notice Returns an output by index. Reverts if output is not found at the given index.
+    /// @param _l2OutputIndex Index of the output to return.
+    /// @return The output at the given index.
+    function getL2Output(uint256 _l2OutputIndex) external view returns (KromaTypes.CheckpointOutput memory) {
+        return l2Outputs[_l2OutputIndex];
+    }
+
+    /// @notice Returns the index of the L2 output that checkpoints a given L2 block number. Uses a
+    ///         binary search to find the first output greater than or equal to the given block.
+    /// @param _l2BlockNumber L2 block number to find a checkpoint for.
+    /// @return Index of the first checkpoint that commits to the given L2 block number.
+    function getL2OutputIndexAfter(uint256 _l2BlockNumber) public view returns (uint256) {
+        // Make sure an output for this block number has actually been submitted.
+        require(
+            _l2BlockNumber <= latestBlockNumber(),
+            "L2OutputOracle: cannot get output for a block that has not been submitted"
+        );
+
+        // Make sure there's at least one output submitted.
+        require(l2Outputs.length > 0, "L2OutputOracle: cannot get output as no outputs have been submitted yet");
+
+        // Find the output via binary search, guaranteed to exist.
+        uint256 lo = 0;
+        uint256 hi = l2Outputs.length;
+        while (lo < hi) {
+            uint256 mid = (lo + hi) / 2;
+            if (l2Outputs[mid].l2BlockNumber < _l2BlockNumber) {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        }
+
+        return lo;
+    }
+
+    /// @notice Returns the L2 checkpoint output that checkpoints a given L2 block number.
+    /// @param _l2BlockNumber L2 block number to find a checkpoint for.
+    /// @return First checkpoint that commits to the given L2 block number.
+    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (KromaTypes.CheckpointOutput memory) {
+        return l2Outputs[getL2OutputIndexAfter(_l2BlockNumber)];
+    }
+
+    /// @notice Returns the index of the latest submitted output. Will revert if no outputs
+    ///         have been submitted yet.
+    /// @return The index of the latest submitted output.
+    function latestOutputIndex() external view returns (uint256) {
+        return l2Outputs.length - 1;
+    }
+
+    /// @notice Returns the index of the next output to be submitted.
+    /// @return The index of the next output to be submitted.
+    function nextOutputIndex() public view returns (uint256) {
+        return l2Outputs.length;
+    }
+
+    /// @notice Returns the block number of the latest submitted L2 checkpoint output. If no outputs
+    ///         have been submitted yet then this function will return the starting block number.
+    /// @return Latest submitted L2 block number.
+    function latestBlockNumber() public view returns (uint256) {
+        return l2Outputs.length == 0 ? startingBlockNumber : l2Outputs[l2Outputs.length - 1].l2BlockNumber;
+    }
+
+    /// @notice Computes the block number of the next L2 block that needs to be checkpointed. If no
+    ///         outputs have been submitted yet then this function will return the latest block
+    ///         number, which is the starting block number.
+    /// @return Next L2 block number.
+    function nextBlockNumber() public view returns (uint256) {
+        return l2Outputs.length == 0 ? latestBlockNumber() : latestBlockNumber() + submissionInterval;
+    }
+
+    /// @notice Returns the L2 timestamp corresponding to a given L2 block number.
+    /// @param _l2BlockNumber The L2 block number of the target block.
+    /// @return L2 timestamp of the given block.
+    function computeL2Timestamp(uint256 _l2BlockNumber) public view returns (uint256) {
+        return startingTimestamp + ((_l2BlockNumber - startingBlockNumber) * l2BlockTime);
+    }
+
+    /// @notice Returns the L2 timestamp corresponding to the right next block of the block that
+    ///         needs to be checkpointed.
+    ///         Note that the added one is because of the existence of next block hash in the output.
+    /// @return L2 timestamp of the right next block of the block that needs to be checkpointed.
+    function nextOutputMinL2Timestamp() public view returns (uint256) {
+        return computeL2Timestamp(nextBlockNumber() + 1);
+    }
+
+    /// @notice Returns the address of the L2 output submitter.
+    /// @param _outputIndex Index of an output.
+    /// @return Address of the submitter.
+    function getSubmitter(uint256 _outputIndex) external view returns (address) {
+        return l2Outputs[_outputIndex].submitter;
+    }
+
+    /// @notice Returns if the output of given index is finalized.
+    /// @param _outputIndex Index of an output.
+    /// @return If the given output is finalized or not.
+    function isFinalized(uint256 _outputIndex) external view returns (bool) {
+        return finalizedAt(_outputIndex) <= block.timestamp;
+    }
+
+    /// @notice Returns the finalization time of given output index.
+    /// @param _outputIndex Index of an output.
+    /// @return The finalization time of given output index.
+    function finalizedAt(uint256 _outputIndex) public view returns (uint256) {
+        return l2Outputs[_outputIndex].timestamp + finalizationPeriodSeconds;
+    }
+}

--- a/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
+++ b/packages/contracts-bedrock/src/L1/L2OutputOracle.sol
@@ -5,15 +5,12 @@ pragma solidity 0.8.15;
 import { Initializable } from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 // Libraries
-import { Constants } from "src/libraries/Constants.sol";
-import { KromaConstants } from "src/libraries/KromaConstants.sol";
-import { KromaTypes } from "src/libraries/KromaTypes.sol";
+import { Types } from "src/libraries/Types.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
 
-/// @custom:proxied
+/// @custom:proxied true
 /// @title L2OutputOracle
 /// @notice The L2OutputOracle contains an array of L2 state outputs, where each output is a
 ///         commitment to the state of the L2 chain. Other contracts like the OptimismPortal use
@@ -25,111 +22,96 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @notice The timestamp of the first L2 block recorded in this contract.
     uint256 public startingTimestamp;
 
-    /// @notice Array of L2 checkpoint outputs.
-    KromaTypes.CheckpointOutput[] internal l2Outputs;
+    /// @notice An array of L2 output proposals.
+    Types.OutputProposal[] internal l2Outputs;
 
-    /// @notice The output index of the next finalization target output.
-    uint256 public nextFinalizeOutputIndex;
-
-    /// @notice The address of the validator manager contract. Can be updated via upgrade.
-    IValidatorManager public validatorManager;
-
-    /// @notice The address of the colosseum contract. Can be updated via upgrade.
-    address public colosseum;
-
-    /// @notice The interval in L2 blocks at which checkpoints must be submitted. Although this is
-    ///         immutable, it can be modified by upgrading the implementation contract.
-    ///         Note that nodes that fetch and use this value need to restart when it is modified.
+    /// @notice The interval in L2 blocks at which checkpoints must be submitted.
+    /// @custom:network-specific
     uint256 public submissionInterval;
 
     /// @notice The time between L2 blocks in seconds. Once set, this value MUST NOT be modified.
+    /// @custom:network-specific
     uint256 public l2BlockTime;
 
-    /// @notice Minimum time (in seconds) that must elapse before a withdrawal can be finalized.
+    /// @notice The address of the challenger. Can be updated via upgrade.
+    /// @custom:network-specific
+    address public challenger;
+
+    /// @notice The address of the proposer. Can be updated via upgrade.
+    /// @custom:network-specific
+    address public proposer;
+
+    /// @notice The minimum time (in seconds) that must elapse before a withdrawal can be finalized.
+    /// @custom:network-specific
     uint256 public finalizationPeriodSeconds;
 
-    /// @notice Emitted when an output is submitted.
+    /// @notice Emitted when an output is proposed.
     /// @param outputRoot    The output root.
     /// @param l2OutputIndex The index of the output in the l2Outputs array.
     /// @param l2BlockNumber The L2 block number of the output root.
-    /// @param l1Timestamp   The L1 timestamp when submitted.
-    event OutputSubmitted(
+    /// @param l1Timestamp   The L1 timestamp when proposed.
+    event OutputProposed(
         bytes32 indexed outputRoot, uint256 indexed l2OutputIndex, uint256 indexed l2BlockNumber, uint256 l1Timestamp
     );
 
-    /// @notice Emitted when an output is replaced.
-    /// @param outputIndex   Replaced L2 output index.
-    /// @param newSubmitter  Output submitter after replacement.
-    /// @param newOutputRoot L2 output root after replacement.
-    event OutputReplaced(uint256 indexed outputIndex, address indexed newSubmitter, bytes32 newOutputRoot);
+    /// @notice Emitted when outputs are deleted.
+    /// @param prevNextOutputIndex Next L2 output index before the deletion.
+    /// @param newNextOutputIndex  Next L2 output index after the deletion.
+    event OutputsDeleted(uint256 indexed prevNextOutputIndex, uint256 indexed newNextOutputIndex);
 
     /// @notice Semantic version.
-    /// @custom:semver 1.2.0
-    string public constant version = "1.2.0";
+    /// @custom:semver 1.8.1-beta.3
+    string public constant version = "1.8.1-beta.3";
 
     /// @notice Constructs the L2OutputOracle contract. Initializes variables to the same values as
     ///         in the getting-started config.
     constructor() {
         initialize({
-            _validatorManager: IValidatorManager(address(0)),
-            _colosseum: address(0),
             _submissionInterval: 1,
             _l2BlockTime: 1,
             _startingBlockNumber: 0,
             _startingTimestamp: 0,
+            _proposer: address(0),
+            _challenger: address(0),
             _finalizationPeriodSeconds: 0
         });
     }
 
-    /// @notice Initializer
-    /// @param _validatorManager          The address of the ValidatorManager contract.
-    /// @param _colosseum                 The address of the Colosseum contract.
-    /// @param _submissionInterval        Interval in blocks at which checkpoints must be submitted.
-    /// @param _l2BlockTime               The time per L2 block, in seconds.
-    /// @param _startingBlockNumber       The number of the first L2 block.
-    /// @param _startingTimestamp         The timestamp of the first L2 block.
-    /// @param _finalizationPeriodSeconds Output finalization time in seconds.
+    /// @notice Initializer.
+    /// @param _submissionInterval  Interval in blocks at which checkpoints must be submitted.
+    /// @param _l2BlockTime         The time per L2 block, in seconds.
+    /// @param _startingBlockNumber The number of the first L2 block.
+    /// @param _startingTimestamp   The timestamp of the first L2 block.
+    /// @param _proposer            The address of the proposer.
+    /// @param _challenger          The address of the challenger.
+    /// @param _finalizationPeriodSeconds The minimum time (in seconds) that must elapse before a withdrawal
+    ///                                   can be finalized.
     function initialize(
-        IValidatorManager _validatorManager,
-        address _colosseum,
         uint256 _submissionInterval,
         uint256 _l2BlockTime,
         uint256 _startingBlockNumber,
         uint256 _startingTimestamp,
+        address _proposer,
+        address _challenger,
         uint256 _finalizationPeriodSeconds
     )
         public
-        reinitializer(2)
+        initializer
     {
-        require(_l2BlockTime > 0, "L2OutputOracle: L2 block time must be greater than 0");
         require(_submissionInterval > 0, "L2OutputOracle: submission interval must be greater than 0");
+        require(_l2BlockTime > 0, "L2OutputOracle: L2 block time must be greater than 0");
         require(
             _startingTimestamp <= block.timestamp,
             "L2OutputOracle: starting L2 timestamp must be less than current time"
         );
-        validatorManager = IValidatorManager(_validatorManager);
-        colosseum = _colosseum;
+
         submissionInterval = _submissionInterval;
         l2BlockTime = _l2BlockTime;
         startingBlockNumber = _startingBlockNumber;
         startingTimestamp = _startingTimestamp;
+        proposer = _proposer;
+        challenger = _challenger;
         finalizationPeriodSeconds = _finalizationPeriodSeconds;
-    }
-
-    /// @notice Getter for the validatorManager address.
-    ///         Public getter is legacy and will be removed in the future. Use `validatorManager` instead.
-    /// @return Address of the validatorManager.
-    /// @custom:legacy
-    function VALIDATOR_MANAGER() external view returns (IValidatorManager) {
-        return validatorManager;
-    }
-
-    /// @notice Getter for the colosseum address.
-    ///         Public getter is legacy and will be removed in the future. Use `colosseum` instead.
-    /// @return Address of the colosseum.
-    /// @custom:legacy
-    function COLOSSEUM() external view returns (address) {
-        return colosseum;
     }
 
     /// @notice Getter for the submissionInterval.
@@ -148,6 +130,22 @@ contract L2OutputOracle is Initializable, ISemver {
         return l2BlockTime;
     }
 
+    /// @notice Getter for the challenger address.
+    ///         Public getter is legacy and will be removed in the future. Use `challenger` instead.
+    /// @return Address of the challenger.
+    /// @custom:legacy
+    function CHALLENGER() external view returns (address) {
+        return challenger;
+    }
+
+    /// @notice Getter for the proposer address.
+    ///         Public getter is legacy and will be removed in the future. Use `proposer` instead.
+    /// @return Address of the proposer.
+    /// @custom:legacy
+    function PROPOSER() external view returns (address) {
+        return proposer;
+    }
+
     /// @notice Getter for the finalizationPeriodSeconds.
     ///         Public getter is legacy and will be removed in the future. Use `finalizationPeriodSeconds` instead.
     /// @return Finalization period in seconds.
@@ -156,42 +154,42 @@ contract L2OutputOracle is Initializable, ISemver {
         return finalizationPeriodSeconds;
     }
 
-    /// @notice Replaces the output that corresponds to the given output index.
-    ///         Only the Colosseum contract can replace an output.
-    /// @param _l2OutputIndex Index of the L2 output to be replaced.
-    /// @param _newOutputRoot The L2 output root to replace the existing one.
-    /// @param _submitter     Address of the L2 output submitter.
-    function replaceL2Output(uint256 _l2OutputIndex, bytes32 _newOutputRoot, address _submitter) external {
-        require(msg.sender == colosseum, "L2OutputOracle: only the colosseum contract can replace an output");
-
-        require(_submitter != address(0), "L2OutputOracle: submitter address cannot be zero");
+    /// @notice Deletes all output proposals after and including the proposal that corresponds to
+    ///         the given output index. Only the challenger address can delete outputs.
+    /// @param _l2OutputIndex Index of the first L2 output to be deleted.
+    ///                       All outputs after this output will also be deleted.
+    function deleteL2Outputs(uint256 _l2OutputIndex) external {
+        require(msg.sender == challenger, "L2OutputOracle: only the challenger address can delete outputs");
 
         // Make sure we're not *increasing* the length of the array.
         require(
-            _l2OutputIndex < l2Outputs.length, "L2OutputOracle: cannot replace an output after the latest output index"
+            _l2OutputIndex < l2Outputs.length, "L2OutputOracle: cannot delete outputs after the latest output index"
         );
 
-        KromaTypes.CheckpointOutput storage output = l2Outputs[_l2OutputIndex];
-        // Do not allow replacing any outputs that have already been finalized.
+        // Do not allow deleting any outputs that have already been finalized.
         require(
-            block.timestamp - output.timestamp < finalizationPeriodSeconds,
-            "L2OutputOracle: cannot replace an output that has already been finalized"
+            block.timestamp - l2Outputs[_l2OutputIndex].timestamp < finalizationPeriodSeconds,
+            "L2OutputOracle: cannot delete outputs that have already been finalized"
         );
 
-        output.outputRoot = _newOutputRoot;
-        output.submitter = _submitter;
+        uint256 prevNextL2OutputIndex = nextOutputIndex();
 
-        emit OutputReplaced(_l2OutputIndex, _submitter, _newOutputRoot);
+        // Use assembly to delete the array elements because Solidity doesn't allow it.
+        assembly {
+            sstore(l2Outputs.slot, _l2OutputIndex)
+        }
+
+        emit OutputsDeleted(prevNextL2OutputIndex, _l2OutputIndex);
     }
 
-    /// @notice Accepts an outputRoot and the block number of the corresponding L2 block.
-    ///         The block number must be equal to the current value returned by `nextBlockNumber()`
-    ///         in order to be accepted. This function may only be called by the validator.
+    /// @notice Accepts an outputRoot and the timestamp of the corresponding L2 block.
+    ///         The timestamp must be equal to the current value returned by `nextTimestamp()` in
+    ///         order to be accepted. This function may only be called by the Proposer.
     /// @param _outputRoot    The L2 output of the checkpoint block.
     /// @param _l2BlockNumber The L2 block number that resulted in _outputRoot.
     /// @param _l1BlockHash   A block hash which must be included in the current chain.
     /// @param _l1BlockNumber The block number with the specified block hash.
-    function submitL2Output(
+    function proposeL2Output(
         bytes32 _outputRoot,
         uint256 _l2BlockNumber,
         bytes32 _l1BlockHash,
@@ -200,75 +198,67 @@ contract L2OutputOracle is Initializable, ISemver {
         external
         payable
     {
-        validatorManager.checkSubmissionEligibility(msg.sender);
+        require(msg.sender == proposer, "L2OutputOracle: only the proposer address can propose new outputs");
 
         require(
             _l2BlockNumber == nextBlockNumber(),
             "L2OutputOracle: block number must be equal to next expected block number"
         );
 
-        require(nextOutputMinL2Timestamp() <= block.timestamp, "L2OutputOracle: cannot submit L2 output in the future");
+        require(
+            computeL2Timestamp(_l2BlockNumber) < block.timestamp,
+            "L2OutputOracle: cannot propose L2 output in the future"
+        );
 
-        require(_outputRoot != bytes32(0), "L2OutputOracle: L2 checkpoint output cannot be the zero hash");
+        require(_outputRoot != bytes32(0), "L2OutputOracle: L2 output proposal cannot be the zero hash");
 
-        if (_l1BlockHash != bytes32(0) && blockhash(_l1BlockNumber) != bytes32(0)) {
-            // This check allows the validator to submit an output based on a given L1 block,
+        if (_l1BlockHash != bytes32(0)) {
+            // This check allows the proposer to propose an output based on a given L1 block,
             // without fear that it will be reorged out.
-            // It will be skipped if the blockheight provided is more than 256 blocks behind the
-            // chain tip (as the hash will return as zero).
+            // It will also revert if the blockheight provided is more than 256 blocks behind the
+            // chain tip (as the hash will return as zero). This does open the door to a griefing
+            // attack in which the proposer's submission is censored until the block is no longer
+            // retrievable, if the proposer is experiencing this attack it can simply leave out the
+            // blockhash value, and delay submission until it is confident that the L1 block is
+            // finalized.
             require(
                 blockhash(_l1BlockNumber) == _l1BlockHash,
                 "L2OutputOracle: block hash does not match the hash at the expected height"
             );
         }
 
+        emit OutputProposed(_outputRoot, nextOutputIndex(), _l2BlockNumber, block.timestamp);
+
         l2Outputs.push(
-            KromaTypes.CheckpointOutput({
-                submitter: msg.sender,
+            Types.OutputProposal({
                 outputRoot: _outputRoot,
                 timestamp: uint128(block.timestamp),
                 l2BlockNumber: uint128(_l2BlockNumber)
             })
         );
-
-        uint256 outputIndex = nextOutputIndex();
-
-        emit OutputSubmitted(_outputRoot, outputIndex, _l2BlockNumber, block.timestamp);
-
-        validatorManager.afterSubmitL2Output(outputIndex);
     }
 
-    /// @notice Updates the next output index to be finalized.
-    /// @param _outputIndex Index of the next output to be finalized.
-    function setNextFinalizeOutputIndex(uint256 _outputIndex) external {
-        require(
-            msg.sender == address(validatorManager),
-            "L2OutputOracle: only the validator manager contract can set next finalize output index"
-        );
-
-        nextFinalizeOutputIndex = _outputIndex;
-    }
-
-    /// @notice Returns an output by index. Reverts if output is not found at the given index.
+    /// @notice Returns an output by index. Needed to return a struct instead of a tuple.
     /// @param _l2OutputIndex Index of the output to return.
     /// @return The output at the given index.
-    function getL2Output(uint256 _l2OutputIndex) external view returns (KromaTypes.CheckpointOutput memory) {
+    function getL2Output(uint256 _l2OutputIndex) external view returns (Types.OutputProposal memory) {
         return l2Outputs[_l2OutputIndex];
     }
 
-    /// @notice Returns the index of the L2 output that checkpoints a given L2 block number. Uses a
-    ///         binary search to find the first output greater than or equal to the given block.
+    /// @notice Returns the index of the L2 output that checkpoints a given L2 block number.
+    ///         Uses a binary search to find the first output greater than or equal to the given
+    ///         block.
     /// @param _l2BlockNumber L2 block number to find a checkpoint for.
     /// @return Index of the first checkpoint that commits to the given L2 block number.
     function getL2OutputIndexAfter(uint256 _l2BlockNumber) public view returns (uint256) {
-        // Make sure an output for this block number has actually been submitted.
+        // Make sure an output for this block number has actually been proposed.
         require(
             _l2BlockNumber <= latestBlockNumber(),
-            "L2OutputOracle: cannot get output for a block that has not been submitted"
+            "L2OutputOracle: cannot get output for a block that has not been proposed"
         );
 
-        // Make sure there's at least one output submitted.
-        require(l2Outputs.length > 0, "L2OutputOracle: cannot get output as no outputs have been submitted yet");
+        // Make sure there's at least one output proposed.
+        require(l2Outputs.length > 0, "L2OutputOracle: cannot get output as no outputs have been proposed yet");
 
         // Find the output via binary search, guaranteed to exist.
         uint256 lo = 0;
@@ -285,39 +275,40 @@ contract L2OutputOracle is Initializable, ISemver {
         return lo;
     }
 
-    /// @notice Returns the L2 checkpoint output that checkpoints a given L2 block number.
+    /// @notice Returns the L2 output proposal that checkpoints a given L2 block number.
+    ///         Uses a binary search to find the first output greater than or equal to the given
+    ///         block.
     /// @param _l2BlockNumber L2 block number to find a checkpoint for.
     /// @return First checkpoint that commits to the given L2 block number.
-    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (KromaTypes.CheckpointOutput memory) {
+    function getL2OutputAfter(uint256 _l2BlockNumber) external view returns (Types.OutputProposal memory) {
         return l2Outputs[getL2OutputIndexAfter(_l2BlockNumber)];
     }
 
-    /// @notice Returns the index of the latest submitted output. Will revert if no outputs
-    ///         have been submitted yet.
-    /// @return The index of the latest submitted output.
+    /// @notice Returns the number of outputs that have been proposed.
+    ///         Will revert if no outputs have been proposed yet.
+    /// @return The number of outputs that have been proposed.
     function latestOutputIndex() external view returns (uint256) {
         return l2Outputs.length - 1;
     }
 
-    /// @notice Returns the index of the next output to be submitted.
-    /// @return The index of the next output to be submitted.
+    /// @notice Returns the index of the next output to be proposed.
+    /// @return The index of the next output to be proposed.
     function nextOutputIndex() public view returns (uint256) {
         return l2Outputs.length;
     }
 
-    /// @notice Returns the block number of the latest submitted L2 checkpoint output. If no outputs
-    ///         have been submitted yet then this function will return the starting block number.
+    /// @notice Returns the block number of the latest submitted L2 output proposal.
+    ///         If no proposals been submitted yet then this function will return the starting
+    ///         block number.
     /// @return Latest submitted L2 block number.
     function latestBlockNumber() public view returns (uint256) {
         return l2Outputs.length == 0 ? startingBlockNumber : l2Outputs[l2Outputs.length - 1].l2BlockNumber;
     }
 
-    /// @notice Computes the block number of the next L2 block that needs to be checkpointed. If no
-    ///         outputs have been submitted yet then this function will return the latest block
-    ///         number, which is the starting block number.
+    /// @notice Computes the block number of the next L2 block that needs to be checkpointed.
     /// @return Next L2 block number.
     function nextBlockNumber() public view returns (uint256) {
-        return l2Outputs.length == 0 ? latestBlockNumber() : latestBlockNumber() + submissionInterval;
+        return latestBlockNumber() + submissionInterval;
     }
 
     /// @notice Returns the L2 timestamp corresponding to a given L2 block number.
@@ -325,34 +316,5 @@ contract L2OutputOracle is Initializable, ISemver {
     /// @return L2 timestamp of the given block.
     function computeL2Timestamp(uint256 _l2BlockNumber) public view returns (uint256) {
         return startingTimestamp + ((_l2BlockNumber - startingBlockNumber) * l2BlockTime);
-    }
-
-    /// @notice Returns the L2 timestamp corresponding to the right next block of the block that
-    ///         needs to be checkpointed.
-    ///         Note that the added one is because of the existence of next block hash in the output.
-    /// @return L2 timestamp of the right next block of the block that needs to be checkpointed.
-    function nextOutputMinL2Timestamp() public view returns (uint256) {
-        return computeL2Timestamp(nextBlockNumber() + 1);
-    }
-
-    /// @notice Returns the address of the L2 output submitter.
-    /// @param _outputIndex Index of an output.
-    /// @return Address of the submitter.
-    function getSubmitter(uint256 _outputIndex) external view returns (address) {
-        return l2Outputs[_outputIndex].submitter;
-    }
-
-    /// @notice Returns if the output of given index is finalized.
-    /// @param _outputIndex Index of an output.
-    /// @return If the given output is finalized or not.
-    function isFinalized(uint256 _outputIndex) external view returns (bool) {
-        return finalizedAt(_outputIndex) <= block.timestamp;
-    }
-
-    /// @notice Returns the finalization time of given output index.
-    /// @param _outputIndex Index of an output.
-    /// @return The finalization time of given output index.
-    function finalizedAt(uint256 _outputIndex) public view returns (uint256) {
-        return l2Outputs[_outputIndex].timestamp + finalizationPeriodSeconds;
     }
 }

--- a/packages/contracts-bedrock/src/L1/OPContractsManager.sol
+++ b/packages/contracts-bedrock/src/L1/OPContractsManager.sol
@@ -6,13 +6,6 @@ import { Blueprint } from "src/libraries/Blueprint.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Claim, Duration, GameType, GameTypes } from "src/dispute/lib/Types.sol";
 
-// Contracts
-import { AssetManager } from "src/L1/AssetManager.sol";
-import { L2OutputOracle } from "src/L1/L2OutputOracle.sol";
-import { SecurityCouncil } from "src/L1/SecurityCouncil.sol";
-import { SystemConfig } from "src/L1/SystemConfig.sol";
-import { ZKProofVerifier } from "src/L1/ZKProofVerifier.sol";
-
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
@@ -35,21 +28,6 @@ import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.s
 import { IL1ERC721Bridge } from "interfaces/L1/IL1ERC721Bridge.sol";
 import { IL1StandardBridge } from "interfaces/L1/IL1StandardBridge.sol";
 import { IOptimismMintableERC20Factory } from "interfaces/universal/IOptimismMintableERC20Factory.sol";
-
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
-import { IColosseum } from "interfaces/L1/IColosseum.sol";
-import { IOptimismPortal } from "interfaces/L1/IOptimismPortal.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
-import { ISecurityCouncil } from "interfaces/L1/ISecurityCouncil.sol";
-import { IValidatorManager } from "interfaces/L1/IValidatorManager.sol";
-import { IZKProofVerifier } from "interfaces/L1/IZKProofVerifier.sol";
-import { ISP1Verifier } from "interfaces/vendor/sp1/ISP1Verifier.sol";
-import { ISecurityCouncilToken } from "interfaces/governance/ISecurityCouncilToken.sol";
-import { ITimeLock } from "interfaces/governance/ITimeLock.sol";
-import { IUpgradeGovernor } from "interfaces/governance/IUpgradeGovernor.sol";
-import { IKromaGovernanceToken } from "interfaces/governance/IKromaGovernanceToken.sol";
 
 contract OPContractsManager is ISemver {
     // -------- Structs --------
@@ -83,39 +61,7 @@ contract OPContractsManager is ISemver {
         uint256 disputeSplitDepth;
         Duration disputeClockExtension;
         Duration disputeMaxClockDuration;
-        // [Kroma: START]
-        // Deploy configs for AssetManager.
-        IERC721 kgh;
-        address vault;
-        uint128 minDelegationPeriod;
-        uint128 bondAmount;
-        // Deploy configs for Colosseum.
-        IL2OutputOracle l2OutputOracle;
-        uint256 submissionInterval;
-        uint256 creationPeriodSeconds;
-        uint256 bisectionTimeout;
-        uint256 provingTimeout;
-        uint256[] segmentsLengths;
-        // Deploy configs for SecurityCouncil.
-        uint256 timeLockMinDelaySeconds;
-        // Deploy configs for UpgradeGovernor.
-        uint256 initialVotingDelay;
-        uint256 initialVotingPeriod;
-        uint256 initialProposalThreshold;
-        uint256 votesQuorumFraction;
-        // Deploy configs for ValidatorManager.
-        address trustedValidator;
-        uint128 minRegisterAmount;
-        uint128 minActivateAmount;
-        uint128 commissionChangeDelaySeconds;
-        uint128 roundDurationSeconds;
-        uint128 softJailPeriodSeconds;
-        uint128 hardJailPeriodSeconds;
-        uint128 jailThreshold;
-        uint128 maxFinalizations;
-        uint128 baseReward;
     }
-    // [Kroma: END]
 
     /// @notice The full set of outputs from deploying a new OP Stack chain.
     struct DeployOutput {
@@ -135,18 +81,7 @@ contract OPContractsManager is ISemver {
         IPermissionedDisputeGame permissionedDisputeGame;
         IDelayedWETH delayedWETHPermissionedGameProxy;
         IDelayedWETH delayedWETHPermissionlessGameProxy;
-        // [Kroma: START]
-        IAssetManager assetManagerProxy;
-        IColosseum colosseumProxy;
-        ISecurityCouncil securityCouncilProxy;
-        ISecurityCouncilToken securityCouncilTokenProxy;
-        ITimeLock timeLockProxy;
-        IUpgradeGovernor upgradeGovernorProxy;
-        IValidatorManager validatorManagerProxy;
-        IZKProofVerifier zkProofVerifierProxy;
-        IKromaGovernanceToken kromaGovernanceTokenProxy;
     }
-    // [Kroma: END]
 
     /// @notice Addresses of ERC-5202 Blueprint contracts. There are used for deploying full size
     /// contracts, to reduce the code size of this factory contract. If it deployed full contracts
@@ -175,17 +110,7 @@ contract OPContractsManager is ISemver {
         address disputeGameFactoryImpl;
         address delayedWETHImpl;
         address mipsImpl;
-        // [Kroma: START]
-        address assetManagerImpl;
-        address colosseumImpl;
-        address securityCouncilImpl;
-        address securityCouncilTokenImpl;
-        address timeLockImpl;
-        address upgradeGovernorImpl;
-        address validatorManagerImpl;
-        address zkProofVerifierImpl;
     }
-    // [Kroma: END]
 
     // -------- Constants and Variables --------
 
@@ -307,26 +232,6 @@ contract OPContractsManager is ISemver {
             IDisputeGameFactory(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "DisputeGameFactory"));
         output.anchorStateRegistryProxy =
             IAnchorStateRegistry(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "AnchorStateRegistry"));
-
-        // [Kroma: START]
-        output.kromaGovernanceTokenProxy =
-            IKromaGovernanceToken(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "KromaGovernanceToken"));
-        output.assetManagerProxy =
-            IAssetManager(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "AssetManager"));
-        output.colosseumProxy = IColosseum(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "Colosseum"));
-        output.securityCouncilProxy =
-            ISecurityCouncil(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "SecurityCouncil"));
-        output.securityCouncilTokenProxy =
-            ISecurityCouncilToken(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "SecurityCouncilToken"));
-        output.timeLockProxy =
-            ITimeLock(payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "TimeLock")));
-        output.upgradeGovernorProxy =
-            IUpgradeGovernor(payable(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "UpgradeGovernor")));
-        output.validatorManagerProxy =
-            IValidatorManager(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "ValidatorManager"));
-        output.zkProofVerifierProxy =
-            IZKProofVerifier(deployProxy(l2ChainId, output.opChainProxyAdmin, saltMixer, "ZKProofVerifier"));
-        // [Kroma: END]
 
         // Deploy legacy proxied contracts.
         output.l1StandardBridgeProxy = IL1StandardBridge(
@@ -450,37 +355,6 @@ contract OPContractsManager is ISemver {
             data
         );
 
-        // [Kroma: START]
-        data = encodeAssetManagerInitializer(_input, output);
-        upgradeAndCall(
-            output.opChainProxyAdmin, address(output.assetManagerProxy), implementation.assetManagerImpl, data
-        );
-        data = encodeColosseumInitializer(_input, output);
-        upgradeAndCall(output.opChainProxyAdmin, address(output.colosseumProxy), implementation.colosseumImpl, data);
-        data = encodeSecurityCouncilInitializer(_input, output);
-        upgradeAndCall(
-            output.opChainProxyAdmin, address(output.securityCouncilProxy), implementation.securityCouncilImpl, data
-        );
-        data = encodeSecurityCouncilTokenInitializer(_input, output);
-        upgradeAndCall(
-            output.opChainProxyAdmin,
-            address(output.securityCouncilTokenProxy),
-            implementation.securityCouncilTokenImpl,
-            data
-        );
-        data = encodeTimeLockInitializer(_input, output);
-        upgradeAndCall(output.opChainProxyAdmin, address(output.timeLockProxy), implementation.timeLockImpl, data);
-        data = encodeUpgradeGovernorInitializer(_input, output);
-        upgradeAndCall(
-            output.opChainProxyAdmin, address(output.upgradeGovernorProxy), implementation.upgradeGovernorImpl, data
-        );
-        data = encodeValidatorManagerInitializer(_input, output);
-        upgradeAndCall(
-            output.opChainProxyAdmin, address(output.validatorManagerProxy), implementation.validatorManagerImpl, data
-        );
-        upgrade(output.opChainProxyAdmin, address(output.zkProofVerifierProxy), implementation.zkProofVerifierImpl);
-        // [Kroma: END]
-
         // -------- Finalize Deployment --------
         // Transfer ownership of the ProxyAdmin from this contract to the specified owner.
         output.opChainProxyAdmin.transferOwnership(_input.roles.opChainProxyAdminOwner);
@@ -526,7 +400,7 @@ contract OPContractsManager is ISemver {
         string memory _saltMixer,
         string memory _contractName
     )
-        public
+        internal
         pure
         returns (bytes32)
     {
@@ -547,24 +421,6 @@ contract OPContractsManager is ISemver {
     {
         bytes32 salt = computeSalt(_l2ChainId, _saltMixer, _contractName);
         return Blueprint.deployFrom(blueprint.proxy, salt, abi.encode(_proxyAdmin));
-    }
-
-    /// @notice Returns the deterministically computed contract address
-    /// that will be deployed by the deployProxy function.
-    function computeDeployProxy(
-        uint256 _l2ChainId,
-        address owner,
-        string memory _saltMixer,
-        string memory _contractName,
-        address _bluePrintTarget,
-        address deployer
-    )
-        public
-        view
-        returns (address)
-    {
-        bytes32 salt = computeSalt(_l2ChainId, _saltMixer, _contractName);
-        return Blueprint.computeDeployAddress(_bluePrintTarget, salt, abi.encode(owner), deployer);
     }
 
     // -------- Initializer Encoding --------
@@ -737,184 +593,6 @@ contract OPContractsManager is ISemver {
         );
     }
 
-    // [Kroma: START]
-
-    /// @notice Helper method for encoding the AssetManager initializer data.
-    function encodeAssetManagerInitializer(
-        DeployInput memory _input,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = IAssetManager.initialize.selector;
-
-        return abi.encodeWithSelector(
-            selector,
-            _output.kromaGovernanceTokenProxy,
-            _input.kgh,
-            _output.securityCouncilProxy,
-            _input.vault,
-            _output.validatorManagerProxy,
-            _input.minDelegationPeriod,
-            _input.bondAmount
-        );
-    }
-
-    /// @notice Helper method for encoding the Colosseum initializer data.
-    function encodeColosseumInitializer(
-        DeployInput memory _input,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = IColosseum.initialize.selector;
-
-        return abi.encodeWithSelector(
-            selector,
-            _input.l2OutputOracle,
-            _output.zkProofVerifierProxy,
-            _output.securityCouncilProxy,
-            _input.submissionInterval,
-            _input.creationPeriodSeconds,
-            _input.bisectionTimeout,
-            _input.provingTimeout,
-            _input.segmentsLengths
-        );
-    }
-
-    /// @notice Helper method for encoding the SecurityCouncil initializer data.
-    function encodeSecurityCouncilInitializer(
-        DeployInput memory,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = SecurityCouncil.initialize.selector;
-
-        return abi.encodeWithSelector(selector, _output.colosseumProxy, _output.upgradeGovernorProxy);
-    }
-
-    /// @notice Helper method for encoding the SecurityCouncilToken initializer data.
-    function encodeSecurityCouncilTokenInitializer(
-        DeployInput memory,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = ISecurityCouncilToken.initialize.selector;
-
-        return abi.encodeWithSelector(selector, _output.upgradeGovernorProxy);
-    }
-
-    /// @notice Helper method for encoding the TimeLock initializer data.
-    function encodeTimeLockInitializer(
-        DeployInput memory _input,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = ITimeLock.initialize.selector;
-        address[] memory proposers = new address[](1);
-        address[] memory executors = new address[](1);
-        proposers[0] = address(_output.upgradeGovernorProxy);
-        executors[0] = address(_output.upgradeGovernorProxy);
-
-        return abi.encodeWithSelector(
-            selector, _input.timeLockMinDelaySeconds, proposers, executors, address(_output.upgradeGovernorProxy)
-        );
-    }
-
-    /// @notice Helper method for encoding the UpgradeGovernor initializer data.
-    function encodeUpgradeGovernorInitializer(
-        DeployInput memory _input,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = IUpgradeGovernor.initialize.selector;
-        return abi.encodeWithSelector(
-            selector,
-            _output.securityCouncilTokenProxy,
-            _output.timeLockProxy,
-            _input.initialVotingDelay,
-            _input.initialVotingPeriod,
-            _input.initialProposalThreshold,
-            _input.votesQuorumFraction
-        );
-    }
-
-    /// @notice Helper method for encoding the ValidatorManager initializer data.
-    function encodeValidatorManagerInitializer(
-        DeployInput memory _input,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = IValidatorManager.initialize.selector;
-
-        IValidatorManager.InitializationParams memory params = IValidatorManager.InitializationParams({
-            _l2Oracle: _input.l2OutputOracle,
-            _assetManager: IAssetManager(_output.assetManagerProxy),
-            _trustedValidator: _input.trustedValidator,
-            _commissionChangeDelaySeconds: _input.commissionChangeDelaySeconds,
-            _roundDurationSeconds: _input.roundDurationSeconds,
-            _softJailPeriodSeconds: _input.softJailPeriodSeconds,
-            _hardJailPeriodSeconds: _input.hardJailPeriodSeconds,
-            _jailThreshold: _input.jailThreshold,
-            _maxOutputFinalizations: _input.maxFinalizations,
-            _baseReward: _input.baseReward,
-            _minRegisterAmount: _input.minRegisterAmount,
-            _minActivateAmount: _input.minActivateAmount
-        });
-
-        return abi.encodeWithSelector(selector, params);
-    }
-
-    /// @notice Helper method for encoding the KromaGovernanceToken initializer data.
-    function encodeKromaGovernanceTokenrInitializer(
-        DeployInput memory _input,
-        DeployOutput memory _output
-    )
-        internal
-        view
-        virtual
-        returns (bytes memory)
-    {
-        bytes4 selector = IKromaGovernanceToken.initialize.selector;
-        return abi.encodeWithSelector(
-            selector,
-            _output.securityCouncilTokenProxy,
-            _output.timeLockProxy,
-            _input.initialVotingDelay,
-            _input.initialVotingPeriod,
-            _input.initialProposalThreshold,
-            _input.votesQuorumFraction
-        );
-    }
-
-    // [Kroma: END]
-
     /// @notice Returns default, standard config arguments for the SystemConfig initializer.
     /// This is used by subclasses to reduce code duplication.
     function defaultSystemConfigParams(
@@ -967,15 +645,6 @@ contract OPContractsManager is ISemver {
         assertValidContractAddress(_implementation);
 
         _proxyAdmin.upgradeAndCall(payable(address(_target)), _implementation, _data);
-    }
-
-    /// @notice Makes an external call to the target to initialize the proxy.
-    function upgrade(IProxyAdmin _proxyAdmin, address _target, address _implementation) internal {
-        assertValidContractAddress(address(_proxyAdmin));
-        assertValidContractAddress(_target);
-        assertValidContractAddress(_implementation);
-
-        _proxyAdmin.upgrade(payable(address(_target)), _implementation);
     }
 
     function assertValidContractAddress(address _who) internal view {

--- a/packages/contracts-bedrock/src/L1/ValidatorManager.sol
+++ b/packages/contracts-bedrock/src/L1/ValidatorManager.sol
@@ -12,7 +12,7 @@ import { Uint128Math } from "src/libraries/Uint128Math.sol";
 
 // Interfaces
 import { IAssetManager } from "interfaces/L1/IAssetManager.sol";
-import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
+import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
 // Contracts
@@ -71,7 +71,7 @@ contract ValidatorManager is ISemver, UnstructuredInitializable {
     /// @custom:field _minRegisterAmount            Minimum amount to register as a validator.
     /// @custom:field _minActivateAmount            Minimum amount to activate a validator.
     struct InitializationParams {
-        IL2OutputOracle _l2Oracle;
+        IKromaL2OutputOracle _l2Oracle;
         IAssetManager _assetManager;
         address _trustedValidator;
         uint128 _commissionChangeDelaySeconds;
@@ -125,7 +125,7 @@ contract ValidatorManager is ISemver, UnstructuredInitializable {
     mapping(uint256 => uint128) internal _pendingChallengeReward;
 
     /// @notice Address of the L2OutputOracle contract. Can be updated via upgrade.
-    IL2OutputOracle public l2Oracle;
+    IKromaL2OutputOracle public l2Oracle;
 
     /// @notice The address of AssetManager contract. Can be updated via upgrade.
     IAssetManager public assetManager;
@@ -322,7 +322,7 @@ contract ValidatorManager is ISemver, UnstructuredInitializable {
     ///         Public getter is legacy and will be removed in the future. Use `l2Oracle` instead.
     /// @return Address of the L2OutputOracle contract.
     /// @custom:legacy
-    function L2_ORACLE() external view returns (IL2OutputOracle) {
+    function L2_ORACLE() external view returns (IKromaL2OutputOracle) {
         return l2Oracle;
     }
 

--- a/packages/contracts-bedrock/src/L1/ValidatorManager.sol
+++ b/packages/contracts-bedrock/src/L1/ValidatorManager.sol
@@ -16,7 +16,7 @@ import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 
 // Contracts
-import { UnstructuredInitializable  } from "src/universal/UnstructuredInitializable.sol";
+import { UnstructuredInitializable } from "src/universal/UnstructuredInitializable.sol";
 
 /// @custom:proxied
 /// @title ValidatorManager

--- a/packages/contracts-bedrock/src/legacy/LegacyOptimismPortal.sol
+++ b/packages/contracts-bedrock/src/legacy/LegacyOptimismPortal.sol
@@ -10,7 +10,6 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { Constants } from "src/libraries/Constants.sol";
 import { Types } from "src/libraries/Types.sol";
-import { KromaTypes } from "src/libraries/KromaTypes.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
 import { Predeploys } from "src/libraries/Predeploys.sol";
@@ -32,7 +31,7 @@ import {
 // Interfaces
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
-import { IKromaL2OutputOracle } from "interfaces/L1/IKromaL2OutputOracle.sol";
+import { IL2OutputOracle } from "interfaces/L1/IL2OutputOracle.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
@@ -43,7 +42,7 @@ import { IL1Block } from "interfaces/L2/IL1Block.sol";
 /// @notice The OptimismPortal is a low-level contract responsible for passing messages between L1
 ///         and L2. Messages sent directly to the OptimismPortal have no form of replayability.
 ///         Users are encouraged to use the L1CrossDomainMessenger for a higher-level interface.
-contract OptimismPortal is Initializable, ResourceMetering, ISemver {
+contract LegacyOptimismPortal is Initializable, ResourceMetering, ISemver {
     /// @notice Allows for interactions with non standard ERC20 tokens.
     using SafeERC20 for IERC20;
 
@@ -87,7 +86,7 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
 
     /// @notice Contract of the L2OutputOracle.
     /// @custom:network-specific
-    IKromaL2OutputOracle public l2Oracle;
+    IL2OutputOracle public l2Oracle;
 
     /// @notice Contract of the SystemConfig.
     /// @custom:network-specific
@@ -147,15 +146,15 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     }
 
     /// @notice Semantic version.
-    /// @custom:semver 2.8.1-beta.5-kroma;
+    /// @custom:semver 2.8.1-beta.5
     function version() public pure virtual returns (string memory) {
-        return "2.8.1-beta.5-kroma";
+        return "2.8.1-beta.5";
     }
 
     /// @notice Constructs the OptimismPortal contract.
     constructor() {
         initialize({
-            _l2Oracle: IKromaL2OutputOracle(address(0)),
+            _l2Oracle: IL2OutputOracle(address(0)),
             _systemConfig: ISystemConfig(address(0)),
             _superchainConfig: ISuperchainConfig(address(0))
         });
@@ -166,7 +165,7 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
     /// @param _systemConfig Contract of the SystemConfig.
     /// @param _superchainConfig Contract of the SuperchainConfig.
     function initialize(
-        IKromaL2OutputOracle _l2Oracle,
+        IL2OutputOracle _l2Oracle,
         ISystemConfig _systemConfig,
         ISuperchainConfig _superchainConfig
     )
@@ -368,9 +367,9 @@ contract OptimismPortal is Initializable, ResourceMetering, ISemver {
             "OptimismPortal: proven withdrawal finalization period has not elapsed"
         );
 
-        // Grab the CheckpointOutput from the L2OutputOracle, will revert if the output that
+        // Grab the OutputProposal from the L2OutputOracle, will revert if the output that
         // corresponds to the given index has not been proposed yet.
-        KromaTypes.CheckpointOutput memory proposal = l2Oracle.getL2Output(provenWithdrawal.l2OutputIndex);
+        Types.OutputProposal memory proposal = l2Oracle.getL2Output(provenWithdrawal.l2OutputIndex);
 
         // Check that the output root that was used to prove the withdrawal is the same as the
         // current output root for the given output index. An output root may change if it is

--- a/packages/contracts-bedrock/src/universal/UnstructuredInitializable.sol
+++ b/packages/contracts-bedrock/src/universal/UnstructuredInitializable.sol
@@ -7,13 +7,11 @@ pragma solidity 0.8.15;
 abstract contract UnstructuredInitializable {
     /// @notice The storage slot that holds the initialized version of the contract.
     /// @dev    Slot: `bytes32(uint256(keccak256("unstructured.initializable.initialized")) - 1)`
-    bytes32 internal constant _INITIALIZED_SLOT =
-        0xb25dec660ce7a75ea4eb44c1b5224935800fab1a1f943d17d507a18ac7a572ed;
+    bytes32 internal constant _INITIALIZED_SLOT = 0xb25dec660ce7a75ea4eb44c1b5224935800fab1a1f943d17d507a18ac7a572ed;
 
     /// @notice The storage slot that tracks whether the contract is in the middle of initializing.
     /// @dev    Slot: `bytes32(uint256(keccak256("unstructured.initializable.initializing")) - 1)`
-    bytes32 internal constant _INITIALIZING_SLOT =
-        0xd16b04d7a8aa3daae4087064b34e44bdfbd8a7259d9f2873842472ff4fff712a;
+    bytes32 internal constant _INITIALIZING_SLOT = 0xd16b04d7a8aa3daae4087064b34e44bdfbd8a7259d9f2873842472ff4fff712a;
 
     /// @notice Emitted whenever the contract is initialized or reinitialized.
     /// @param version The version number that was initialized.
@@ -24,8 +22,7 @@ abstract contract UnstructuredInitializable {
     modifier initializer() {
         bool isTopLevelCall = !_isInitializing();
         require(
-            _getInitializedVersion() < 1 || (isTopLevelCall && !_isInitialized()),
-            "Initializable: already initialized"
+            _getInitializedVersion() < 1 || (isTopLevelCall && !_isInitialized()), "Initializable: already initialized"
         );
 
         _setInitializedVersion(1);
@@ -44,10 +41,7 @@ abstract contract UnstructuredInitializable {
     /// @param version The initialization version to apply.
     modifier reinitializer(uint8 version) {
         require(!_isInitializing(), "Initializable: contract is initializing");
-        require(
-            _getInitializedVersion() < version,
-            "Initializable: already initialized"
-        );
+        require(_getInitializedVersion() < version, "Initializable: already initialized");
 
         _setInitializedVersion(version);
         _setInitializing(true);

--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -86,35 +86,8 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
             disputeMaxGameDepth: _doi.disputeMaxGameDepth(),
             disputeSplitDepth: _doi.disputeSplitDepth(),
             disputeClockExtension: _doi.disputeClockExtension(),
-            disputeMaxClockDuration: _doi.disputeMaxClockDuration(),
-            // [Kroma: START]
-            kgh: _doi.kgh(),
-            vault: _doi.vault(),
-            minDelegationPeriod: _doi.minDelegationPeriod(),
-            bondAmount: _doi.bondAmount(),
-            l2OutputOracle: _doi.l2OutputOracle(),
-            submissionInterval: _doi.submissionInterval(),
-            creationPeriodSeconds: _doi.creationPeriodSeconds(),
-            bisectionTimeout: _doi.bisectionTimeout(),
-            provingTimeout: _doi.provingTimeout(),
-            segmentsLengths: _doi.segmentsLengths(),
-            timeLockMinDelaySeconds: _doi.timeLockMinDelaySeconds(),
-            initialVotingDelay: _doi.initialVotingDelay(),
-            initialVotingPeriod: _doi.initialVotingPeriod(),
-            initialProposalThreshold: _doi.initialProposalThreshold(),
-            votesQuorumFraction: _doi.votesQuorumFraction(),
-            trustedValidator: _doi.trustedValidator(),
-            minRegisterAmount: _doi.minRegisterAmount(),
-            minActivateAmount: _doi.minActivateAmount(),
-            commissionChangeDelaySeconds: _doi.commissionChangeDelaySeconds(),
-            roundDurationSeconds: _doi.roundDurationSeconds(),
-            softJailPeriodSeconds: _doi.softJailPeriodSeconds(),
-            hardJailPeriodSeconds: _doi.hardJailPeriodSeconds(),
-            jailThreshold: _doi.jailThreshold(),
-            maxFinalizations: _doi.maxFinalizations(),
-            baseReward: _doi.baseReward()
+            disputeMaxClockDuration: _doi.disputeMaxClockDuration()
         });
-        // [Kroma: END]
     }
 
     function test_deploy_l2ChainIdEqualsZero_reverts() public {

--- a/packages/contracts-bedrock/test/universal/UnstructuredInitializableTest.t.sol
+++ b/packages/contracts-bedrock/test/universal/UnstructuredInitializableTest.t.sol
@@ -5,7 +5,7 @@ pragma solidity 0.8.15;
 import "forge-std/Test.sol";
 
 // Contracts
-import {UnstructuredInitializable} from "src/universal/UnstructuredInitializable.sol";
+import { UnstructuredInitializable } from "src/universal/UnstructuredInitializable.sol";
 
 /// @dev A simple contract that inherits UnstructuredInitializable for testing.
 contract TestContract is UnstructuredInitializable {


### PR DESCRIPTION
Summary

This PR decouples the Kroma deployment logic from the Optimism deployment scripts, which were previously tightly coupled.

What’s changed
- Modularized Kroma deployment logic into a standalone library format

- Minimized code overlap with existing Optimism deploy code

- Improved maintainability and clarity by isolating Kroma-specific logic

Why it matters
By isolating Kroma deployment logic, we reduce interference with upstream Optimism code. This ensures smoother upstream merges and preserves the behavior of the original OP deployment flow.
